### PR TITLE
feat: Configurable IaC tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ Temporary Items
 ### Terraform ###
 # Local .terraform directories
 **/.terraform/*
+**/.tofurc
+**/.tofu.rc
 
 # Crash log files
 crash.log

--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ The following options are present:
 
 There is also a default volume of 16gb created and mounted at the /data directory, you can change this in each specific app type if desired
 
+## Switching out IaC Tools
+By default, DeployEx uses Terraform and Ansible for infrastructure as code (IaC) tools.
+However, you can switch to, e.g., [OpenTofu](https://opentofu.org/) using the `:iac_tool` option
+in `:deploy_ex` config. This should point to the binary for the installed IaC tool:
+
+```elixir
+config :deploy_ex, iac_tool: "tofu
+```
+
 ## Ansible Options
 - `inventory` (alias: `e`) - [Ansible inventories](https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html)
 - `limit` (alias: `i`) - [Ansible limiting/filtering](https://docs.ansible.com/ansible/latest/inventory_guide/intro_patterns.html#patterns-and-ad-hoc-commands) to target specific servers

--- a/lib/deploy_ex/config.ex
+++ b/lib/deploy_ex/config.ex
@@ -1,6 +1,8 @@
 defmodule DeployEx.Config do
   @app :deploy_ex
 
+  def iac_tool, do: Application.get_env(@app, :iac_tool) || "terraform"
+
   def env, do: Application.get_env(@app, :env) || "dev"
   def aws_region, do: Application.get_env(@app, :aws_region) || "us-west-2"
 

--- a/lib/mix/tasks/terraform.apply.ex
+++ b/lib/mix/tasks/terraform.apply.ex
@@ -19,6 +19,7 @@ defmodule Mix.Tasks.Terraform.Apply do
     opts = args
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
+      |> Keyword.put(:iac_tool, DeployEx.Config.iac_tool())
 
     with :ok <- DeployExHelpers.check_in_umbrella(),
          :ok <- run_command(args, opts) do
@@ -43,7 +44,7 @@ defmodule Mix.Tasks.Terraform.Apply do
   end
 
   defp run_command(args, opts) do
-    cmd = "terraform apply #{DeployExHelpers.to_terraform_args(args)}"
+    cmd = "#{opts[:iac_tool]} apply #{DeployExHelpers.to_terraform_args(args)}"
     cmd = if opts[:auto_approve], do: "#{cmd} --auto-approve", else: cmd
 
     DeployExHelpers.run_command_with_input(cmd, opts[:directory])

--- a/lib/mix/tasks/terraform.build.ex
+++ b/lib/mix/tasks/terraform.build.ex
@@ -27,6 +27,7 @@ defmodule Mix.Tasks.Terraform.Build do
     opts = args
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
+      |> Keyword.put(:iac_tool, DeployEx.Config.iac_tool())
       |> Keyword.put_new(:aws_region, @default_aws_region)
       |> Keyword.put_new(:aws_release_bucket, @default_aws_release_bucket)
       |> Keyword.put_new(:aws_log_bucket, DeployEx.Config.aws_log_bucket())
@@ -69,7 +70,7 @@ defmodule Mix.Tasks.Terraform.Build do
       }
 
       write_terraform_template_files(params, opts)
-      run_terraform_init(params)
+      run_terraform_init(params, opts)
     else
       {:error, e} -> Mix.raise(to_string(e))
     end
@@ -97,8 +98,11 @@ defmodule Mix.Tasks.Terraform.Build do
     opts
   end
 
-  defp run_terraform_init(params) do
-    DeployExHelpers.run_command_with_input("terraform init", params[:directory])
+  defp run_terraform_init(params, opts) do
+    DeployExHelpers.run_command_with_input(
+      "#{opts[:iac_tool]} init",
+      params[:directory]
+    )
   end
 
   defp ensure_terraform_directory_exists(directory) do

--- a/lib/mix/tasks/terraform.drop.ex
+++ b/lib/mix/tasks/terraform.drop.ex
@@ -12,9 +12,10 @@ defmodule Mix.Tasks.Terraform.Drop do
     opts = args
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
+      |> Keyword.put(:iac_tool, DeployEx.Config.iac_tool())
 
     with :ok <- DeployExHelpers.check_in_umbrella() do
-      cmd = "terraform destroy #{DeployExHelpers.to_terraform_args(args)}"
+      cmd = "#{DeployEx.Config.iac_tool()} destroy #{DeployExHelpers.to_terraform_args(args)}"
       cmd = if opts[:auto_approve], do: "#{cmd} --auto-approve", else: cmd
 
       DeployExHelpers.run_command_with_input(cmd, opts[:directory])

--- a/lib/mix/tasks/terraform.init.ex
+++ b/lib/mix/tasks/terraform.init.ex
@@ -12,6 +12,7 @@ defmodule Mix.Tasks.Terraform.Init do
     opts = args
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
+      |> Keyword.put(:iac_tool, DeployEx.Config.iac_tool())
 
     with :ok <- DeployExHelpers.check_in_umbrella(),
          :ok <- run_terraform_init(args, opts) do
@@ -34,7 +35,7 @@ defmodule Mix.Tasks.Terraform.Init do
   end
 
   defp run_terraform_init(args, opts) do
-    cmd = "terraform init #{DeployExHelpers.to_terraform_args(args)}"
+    cmd = "#{opts[:iac_tool]} init #{DeployExHelpers.to_terraform_args(args)}"
     cmd = if opts[:upgrade], do: "#{cmd} --upgrade", else: cmd
 
     DeployExHelpers.run_command_with_input(cmd, opts[:directory])

--- a/lib/mix/tasks/terraform.plan.ex
+++ b/lib/mix/tasks/terraform.plan.ex
@@ -19,6 +19,7 @@ defmodule Mix.Tasks.Terraform.Plan do
     opts = args
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
+      |> Keyword.put(:iac_tool, DeployEx.Config.iac_tool())
 
     with :ok <- DeployExHelpers.check_in_umbrella(),
          :ok <- run_command(args, opts) do
@@ -42,7 +43,7 @@ defmodule Mix.Tasks.Terraform.Plan do
   end
 
   defp run_command(args, opts) do
-    cmd = "terraform plan #{DeployExHelpers.to_terraform_args(args)}"
+    cmd = "#{opts[:iac_tool]} plan #{DeployExHelpers.to_terraform_args(args)}"
 
     DeployExHelpers.run_command_with_input(cmd, opts[:directory])
   end

--- a/lib/mix/tasks/terraform.refresh.ex
+++ b/lib/mix/tasks/terraform.refresh.ex
@@ -12,9 +12,13 @@ defmodule Mix.Tasks.Terraform.Refresh do
     opts = args
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
+      |> Keyword.put(:iac_tool, DeployEx.Config.iac_tool())
 
     with :ok <- DeployExHelpers.check_in_umbrella() do
-      DeployExHelpers.run_command_with_input("terraform refresh #{DeployExHelpers.to_terraform_args(args)}", opts[:directory])
+      DeployExHelpers.run_command_with_input(
+        "#{opts[:iac_tool]} refresh #{DeployExHelpers.to_terraform_args(args)}",
+        opts[:directory]
+      )
     end
   end
 

--- a/lib/mix/tasks/terraform.replace.ex
+++ b/lib/mix/tasks/terraform.replace.ex
@@ -19,6 +19,11 @@ defmodule Mix.Tasks.Terraform.Replace do
   def run(args) do
     {opts, extra_args} = parse_args(args)
 
+    opts = args
+      |> parse_args
+      |> Keyword.put_new(:directory, @terraform_default_path)
+      |> Keyword.put(:iac_tool, DeployEx.Config.iac_tool())
+
     with :ok <- DeployExHelpers.check_in_umbrella() do
       if opts[:string] do
         terraform_apply_replace(opts[:string], DeployExHelpers.to_terraform_args(args), opts)
@@ -46,7 +51,7 @@ defmodule Mix.Tasks.Terraform.Replace do
   end
 
   defp terraform_apply_replace(replace_str, terraform_args, opts) do
-    cmd = "terraform apply #{terraform_args} --replace \"#{replace_str}\""
+    cmd = "#{opts[:iac_tool]} apply #{terraform_args} --replace \"#{replace_str}\""
     cmd = if opts[:auto_approve], do: "#{cmd} --auto-approve", else: cmd
 
     DeployExHelpers.run_command_with_input(cmd, opts[:directory])
@@ -68,7 +73,7 @@ defmodule Mix.Tasks.Terraform.Replace do
       ]
     )
 
-    {Keyword.put_new(opts, :directory, @terraform_default_path), extra_args}
+    {opts, extra_args}
   end
 
   defp get_instances_from_args(instances, [instance_name], opts) do
@@ -126,4 +131,3 @@ defmodule Mix.Tasks.Terraform.Replace do
     end)
   end
 end
-


### PR DESCRIPTION
* Adds support for replacing Terraform with another IaC tool, such as OpenTofu
* Assumes a matching API currently—could be improved on at some point
* Does not attempt to address or change the naming throughout DeployEx config of terraform-based functionality, or validate other possibly related configuration, such as the path for IaC tool configuration files. E.g. introduces a possible conflict between compile-time and runtime config, where the `directory` option for terraform may be defaulted at compile-time