### PR TITLE
feat: support single-app projects (not just umbrellas)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 *Important: This requires [Terraform](https://terraform.io) and [Ansible](https://www.ansible.com/) to be installed to use the commands*
 
-This library allows you to add deployment to your umbrella application using AWS EC2, Ansible and Terraform
+This library allows you to add deployment to your Elixir application using AWS EC2, Ansible and Terraform.
+It supports both umbrella projects and standard single-app projects
 
 By default it uses `t3.nano` nodes but this can be changed in `./deploys/terraform/modules/aws-instance/variables.tf`
 Once the files are generated, you can manage all files yourself, and we'll attempt to inject the variables in upon
@@ -86,8 +87,8 @@ remote machines
 All releases in the app must have a `:tar` step at the end of their `steps`
 
 ## TL;DR Installation
-Make sure you have your `releases` configured in your root `mix.exs`. This command will only
-function in the root of an umbrella app.
+Make sure you have your `releases` configured in your root `mix.exs`. For single-app projects
+without an explicit `releases` key, deploy_ex will synthesize one from your `:app` name.
 
 By default nodes will be generated for prometheus, grafana ui, grafana loki and sentry. To turn this
 off pass the options when calling `deploy_ex.full_setup`, `terraform.build` or `ansible.build`:
@@ -232,7 +233,7 @@ Because the terraform and ansible files are generated directly into your applica
 You can make changes to ansible and terraform files as you see fit. In the case of terraform, it will automatically
 inject the apps into your variables file despite changes to the file. If you change terraform, make sure to run `mix terraform.apply`
 
-### Multiple Phoenix Apps
+### Multiple Phoenix Apps (Umbrella Only)
 In order to have multiple phoenix apps in the umbrella supported, we need to configure our
 `:dart_sass`, `:tailwind` and `:esbuild` to support multiple apps by changing the key from default
 to the key of each app and setting the proper `cd` and `NODE_PATH`
@@ -1245,7 +1246,7 @@ of the github action file that gets generated.
 By default the github action will not redeploy unchanged applications, it will run a diff in git to determine changes and only
 change on the following conditions:
 - Code change in the app
-- Code change in a related umbrella app
+- Code change in a related umbrella app (umbrella projects only)
 - Dependency changes in mix.lock
 - The release hasn't been uploaded to S3 already
 

--- a/lib/deploy_ex/project_context.ex
+++ b/lib/deploy_ex/project_context.ex
@@ -1,0 +1,94 @@
+defmodule DeployEx.ProjectContext do
+  alias DeployEx.ReleaseUploader.RedeployConfig
+
+  @spec type(module()) :: :umbrella | :single_app
+  def type(mix_project \\ Mix.Project) do
+    if mix_project.umbrella?(), do: :umbrella, else: :single_app
+  end
+
+  @spec apps(module()) :: [String.t()]
+  def apps(mix_project \\ Mix.Project) do
+    case type(mix_project) do
+      :umbrella ->
+        mix_project.apps_paths()
+        |> Map.keys()
+        |> Enum.map(&to_string/1)
+        |> Enum.sort()
+
+      :single_app ->
+        [to_string(mix_project.get().project()[:app])]
+    end
+  end
+
+  @spec app_path(String.t(), module()) :: String.t() | nil
+  def app_path(app_name, mix_project \\ Mix.Project) do
+    case type(mix_project) do
+      :umbrella ->
+        Map.get(mix_project.apps_paths(), String.to_atom(app_name))
+
+      :single_app ->
+        File.cwd!()
+    end
+  end
+
+  @spec releases(module()) :: {:ok, keyword()} | {:error, ErrorMessage.t()}
+  def releases(mix_project \\ Mix.Project) do
+    project_module = mix_project.get()
+
+    if is_nil(project_module) do
+      {:error, ErrorMessage.not_found("couldn't find mix project")}
+    else
+      opts = project_module.project()
+
+      cond do
+        opts[:releases] ->
+          {:ok, opts[:releases]}
+
+        type(mix_project) === :single_app and opts[:app] ->
+          app_name = opts[:app]
+          {:ok, [{app_name, [applications: [{app_name, :permanent}]]}]}
+
+        true ->
+          {:error, ErrorMessage.not_found("no releases defined and could not infer app name")}
+      end
+    end
+  end
+
+  @spec redeploy_config(atom(), module()) ::
+          {:ok, RedeployConfig.t()} | {:error, ErrorMessage.t()}
+  def redeploy_config(release_name, mix_project \\ Mix.Project) do
+    with {:ok, releases} <- releases(mix_project) do
+      deploy_ex_opts = releases |> Keyword.get(release_name, []) |> Keyword.get(:deploy_ex, [])
+      redeploy_opts = Keyword.get(deploy_ex_opts, :redeploy_config, [])
+
+      config = %RedeployConfig{
+        whitelist: redeploy_opts[:whitelist],
+        blacklist: redeploy_opts[:blacklist]
+      }
+
+      {:ok, config}
+    end
+  end
+
+  @spec check_valid_project(module()) :: :ok | {:error, ErrorMessage.t()}
+  def check_valid_project(mix_project \\ Mix.Project) do
+    project_module = mix_project.get()
+
+    cond do
+      is_nil(project_module) ->
+        {:error, ErrorMessage.bad_request("could not find mix project")}
+
+      mix_project.umbrella?() ->
+        :ok
+
+      project_module.project()[:app] ->
+        :ok
+
+      true ->
+        {:error,
+         ErrorMessage.bad_request(
+           "could not determine apps for this project — ensure mix.exs defines :app or :releases"
+         )}
+    end
+  end
+end

--- a/lib/deploy_ex/project_context.ex
+++ b/lib/deploy_ex/project_context.ex
@@ -23,11 +23,8 @@ defmodule DeployEx.ProjectContext do
   @spec app_path(String.t(), module()) :: String.t() | nil
   def app_path(app_name, mix_project \\ Mix.Project) do
     case type(mix_project) do
-      :umbrella ->
-        Map.get(mix_project.apps_paths(), String.to_atom(app_name))
-
-      :single_app ->
-        File.cwd!()
+      :umbrella -> Map.get(mix_project.apps_paths(), String.to_atom(app_name))
+      :single_app -> File.cwd!()
     end
   end
 

--- a/lib/deploy_ex/release_uploader/update_validator.ex
+++ b/lib/deploy_ex/release_uploader/update_validator.ex
@@ -1,19 +1,14 @@
 defmodule DeployEx.ReleaseUploader.UpdateValidator do
-  alias DeployEx.ReleaseUploader.{
-    RedeployConfig,
-    UpdateValidator.MixDepsTreeParser,
-    UpdateValidator.MixLockFileDiffParser
-  }
+  alias DeployEx.ReleaseUploader.{RedeployConfig, UpdateValidator.MixDepsTreeParser, UpdateValidator.MixLockFileDiffParser}
 
   @max_git_diff_concurrency 2
 
   def filter_changed(release_states) do
     with {:ok, file_diffs_by_sha_tuple} <- load_file_diffs(release_states),
-         {:ok,
-          {
-            {invalid_release_states, release_states},
-            file_diffs_by_sha_tuple
-          }} <- split_invalid_releases(release_states, file_diffs_by_sha_tuple),
+         {:ok, {
+           {invalid_release_states, release_states},
+           file_diffs_by_sha_tuple
+         }} <- split_invalid_releases(release_states, file_diffs_by_sha_tuple),
          {:ok, dep_changes_by_sha_tuple} <- load_dep_changes(file_diffs_by_sha_tuple),
          {:ok, app_dep_tree} <- MixDepsTreeParser.load_app_dep_tree() do
       filter_changed(
@@ -27,80 +22,73 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
   end
 
   def filter_changed(
-        invalid_release_states,
-        release_states,
-        file_diffs_by_sha_tuple,
-        dep_changes_by_sha_tuple,
-        app_dep_tree
-      ) do
-    {never_uploaded_releases, release_states} =
-      Enum.split_with(
-        release_states,
-        &is_nil(&1.last_sha)
-      )
+    invalid_release_states,
+    release_states,
+    file_diffs_by_sha_tuple,
+    dep_changes_by_sha_tuple,
+    app_dep_tree
+  ) do
+    {never_uploaded_releases, release_states} = Enum.split_with(
+      release_states,
+      &is_nil(&1.last_sha)
+    )
 
-    {:ok,
-     never_uploaded_releases ++
-       invalid_release_states ++
-       Enum.filter(release_states, fn release_state ->
-         release_has_code_changes?(release_state, file_diffs_by_sha_tuple) or
-           release_has_local_dep_changes?(release_state, file_diffs_by_sha_tuple, app_dep_tree) or
-           release_has_dep_changes?(release_state, dep_changes_by_sha_tuple, app_dep_tree)
-       end)}
+    {:ok, never_uploaded_releases ++ invalid_release_states ++ Enum.filter(release_states, fn release_state ->
+      release_has_code_changes?(release_state, file_diffs_by_sha_tuple) or
+      release_has_local_dep_changes?(release_state, file_diffs_by_sha_tuple, app_dep_tree) or
+      release_has_dep_changes?(release_state, dep_changes_by_sha_tuple, app_dep_tree)
+    end)}
   end
 
   def split_invalid_releases(release_states, file_diffs_by_sha_tuple) do
-    split_release_states =
-      Enum.split_with(
-        release_states,
-        &uploaded_release_invalid?(&1, file_diffs_by_sha_tuple)
-      )
+    split_release_states = Enum.split_with(
+      release_states,
+      &uploaded_release_invalid?(&1, file_diffs_by_sha_tuple)
+    )
 
-    file_diffs_by_sha_tuple =
-      file_diffs_by_sha_tuple
+    file_diffs_by_sha_tuple = file_diffs_by_sha_tuple
       |> Enum.reject(fn
         {_, [:invalid]} -> true
         _ -> false
       end)
-      |> Map.new()
+      |> Map.new
 
     {:ok, {split_release_states, file_diffs_by_sha_tuple}}
   end
 
   def load_file_diffs(states) do
-    from_to_shas = states |> Enum.map(&{&1.sha, &1.last_sha}) |> Enum.uniq()
+    from_to_shas = states |> Enum.map(&{&1.sha, &1.last_sha}) |> Enum.uniq
 
     with {:ok, file_diffs} <- file_diffs_between(from_to_shas) do
       file_diffs
-      |> Enum.reject(fn
-        {_sha_tuple, [""]} -> true
-        {_sha_tuple, []} -> true
-        {_sha_tuple, _} -> false
-      end)
-      |> Map.new()
-      |> then(&{:ok, &1})
+        |> Enum.reject(fn
+          {_sha_tuple, [""]} -> true
+          {_sha_tuple, []} -> true
+          {_sha_tuple, _} -> false
+        end)
+        |> Map.new
+        |> then(&{:ok, &1})
     end
   end
 
   def load_dep_changes(file_diffs_by_sha_tuple) do
-    res =
-      file_diffs_by_sha_tuple
+    res = file_diffs_by_sha_tuple
       |> filter_file_diffs_for_deps_update
       |> Task.async_stream(
         &MixLockFileDiffParser.git_diff_mix_lock/1,
         max_concurrency: @max_git_diff_concurrency
       )
-      |> DeployEx.Utils.reduce_task_status_tuples()
+      |> DeployEx.Utils.reduce_task_status_tuples
 
     with {:ok, file_diffs_by_sha_tuple} <- res do
       file_diffs_by_sha_tuple
-      |> Enum.reject(fn
-        {_sha_tuple, [""]} -> true
-        {_sha_tuple, []} -> true
-        _ -> false
-      end)
-      |> Map.new()
-      |> then(&{:ok, &1})
+        |> Enum.reject(fn
+          {_sha_tuple, [""]} -> true
+          {_sha_tuple, []} -> true
+          _ -> false
+        end)
+        |> Map.new
+        |> then(&{:ok, &1})
     end
   end
 
@@ -112,78 +100,63 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
 
   defp file_diffs_between(from_to_shas) do
     from_to_shas
-    |> Task.async_stream(
-      fn {current_sha, last_sha} = sha_tuple ->
+      |> Task.async_stream(fn {current_sha, last_sha} = sha_tuple ->
         with {:ok, file_diffs} <- git_diff_files_between(current_sha, last_sha) do
           {:ok, {sha_tuple, file_diffs}}
         end
-      end,
-      max_concurrency: @max_git_diff_concurrency
-    )
-    |> DeployEx.Utils.reduce_task_status_tuples()
+      end, max_concurrency: @max_git_diff_concurrency)
+      |> DeployEx.Utils.reduce_task_status_tuples
   end
 
   defp git_diff_files_between(current_sha, last_sha) do
     case System.shell("git diff --name-only #{current_sha}..#{last_sha} --") do
-      {output, 0} ->
-        {:ok, output |> String.trim_trailing("\n") |> String.split("\n")}
+      {output, 0} -> {:ok, output |> String.trim_trailing("\n") |> String.split("\n")}
+      {"", 128} -> {:ok, [:invalid]}
 
-      {"", 128} ->
-        {:ok, [:invalid]}
-
-      {output, code} ->
-        {:error,
-         ErrorMessage.failed_dependency(
-           "couldn't run git diff --name-only",
-           %{output: output, code: code}
-         )}
+      {output, code} -> {:error, ErrorMessage.failed_dependency(
+        "couldn't run git diff --name-only",
+        %{output: output, code: code}
+      )}
     end
   end
 
-  defp uploaded_release_invalid?(
-         %DeployEx.ReleaseUploader.State{
-           sha: current_sha,
-           last_sha: last_sha
-         },
-         file_diffs_by_sha_tuple
-       ) do
+  defp uploaded_release_invalid?(%DeployEx.ReleaseUploader.State{
+    sha: current_sha,
+    last_sha: last_sha
+  }, file_diffs_by_sha_tuple) do
     Map.get(file_diffs_by_sha_tuple, {current_sha, last_sha}) === [:invalid]
   end
 
-  defp release_has_code_changes?(
-         %DeployEx.ReleaseUploader.State{
-           app_name: release_app_name,
-           sha: current_sha,
-           last_sha: last_sha,
-           release_apps: release_apps,
-           redeploy_config: redeploy_config
-         },
-         file_diffs_by_sha_tuple
-       ) do
+  defp release_has_code_changes?(%DeployEx.ReleaseUploader.State{
+    app_name: release_app_name,
+    sha: current_sha,
+    last_sha: last_sha,
+    release_apps: release_apps,
+    redeploy_config: redeploy_config
+  }, file_diffs_by_sha_tuple) do
     file_diffs = Map.get(file_diffs_by_sha_tuple, {current_sha, last_sha}) || []
 
-    Enum.any?(file_diffs) &&
-      Enum.any?(release_apps, fn app_name ->
-        filtered_diffs = RedeployConfig.filter_file_diffs(file_diffs, app_name, redeploy_config)
+    Enum.any?(file_diffs) && Enum.any?(release_apps, fn app_name ->
+      filtered_diffs = RedeployConfig.filter_file_diffs(file_diffs, app_name, redeploy_config)
 
-        root_mix_exs_change? = Enum.any?(filtered_diffs, &(&1 === "mix.exs"))
-        code_change? = Enum.any?(filtered_diffs, &file_part_of_app(&1, app_name))
-        config_change? = Enum.any?(filtered_diffs, &config_file?(&1))
-        rel_file_change? = Enum.any?(filtered_diffs, &rel_file?(&1))
+      root_mix_exs_change? = Enum.any?(filtered_diffs, &(&1 === "mix.exs"))
+      code_change? = Enum.any?(filtered_diffs, &file_part_of_app(&1, app_name))
+      config_change? = Enum.any?(filtered_diffs, &config_file?(&1))
+      rel_file_change? = Enum.any?(filtered_diffs, &rel_file?(&1))
 
-        changes = if config_change?, do: ["config"], else: []
-        changes = if root_mix_exs_change?, do: ["root mix.exs" | changes], else: changes
-        changes = if code_change?, do: ["code" | changes], else: changes
-        changes = if rel_file_change?, do: ["release file" | changes], else: changes
+      changes = if config_change?, do: ["config"], else: []
+      changes = if root_mix_exs_change?, do: ["root mix.exs" | changes], else: changes
+      changes = if code_change?, do: ["code" | changes], else: changes
+      changes = if rel_file_change?, do: ["release file" | changes], else: changes
 
-        changes? = Enum.any?(changes)
+      changes? = Enum.any?(changes)
 
-        if changes? do
-          log_app_change(changes, release_app_app_name_string(release_app_name, app_name))
-        end
+      if changes? do
+        log_app_change(changes, release_app_app_name_string(release_app_name, app_name))
+      end
 
-        changes?
-      end)
+      changes?
+    end)
   end
 
   def log_app_change([], _) do
@@ -191,42 +164,21 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
   end
 
   def log_app_change([change], app_name) do
-    IO.puts(
-      to_string(
-        IO.ANSI.format([
-          :green,
-          "* #{change} changes detected ",
-          :reset,
-          app_name
-        ])
-      )
-    )
+    IO.puts(to_string(IO.ANSI.format([
+      :green, "* #{change} changes detected ", :reset, app_name
+    ])))
   end
 
   def log_app_change([change_a, change_b], app_name) do
-    IO.puts(
-      to_string(
-        IO.ANSI.format([
-          :green,
-          "* #{change_a} & #{change_b} changes detected ",
-          :reset,
-          app_name
-        ])
-      )
-    )
+    IO.puts(to_string(IO.ANSI.format([
+      :green, "* #{change_a} & #{change_b} changes detected ", :reset, app_name
+    ])))
   end
 
   def log_app_change([change_a | changes], app_name) do
-    IO.puts(
-      to_string(
-        IO.ANSI.format([
-          :green,
-          "* #{Enum.join(changes, ", ")} & #{change_a} changes detected ",
-          :reset,
-          app_name
-        ])
-      )
-    )
+    IO.puts(to_string(IO.ANSI.format([
+      :green, "* #{Enum.join(changes, ", ")} & #{change_a} changes detected ", :reset, app_name
+    ])))
   end
 
   defp file_part_of_app(diff, app_name) do
@@ -242,37 +194,27 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
     diff =~ ~r/config\/[a-z0-9A-Z\.-_]+.exs/
   end
 
-  defp release_has_dep_changes?(
-         %DeployEx.ReleaseUploader.State{
-           app_name: release_app_name,
-           sha: current_sha,
-           last_sha: last_sha,
-           release_apps: release_apps,
-           redeploy_config: redeploy_config
-         },
-         dep_changes_by_sha_tuple,
-         app_dep_tree
-       ) do
+  defp release_has_dep_changes?(%DeployEx.ReleaseUploader.State{
+    app_name: release_app_name,
+    sha: current_sha,
+    last_sha: last_sha,
+    release_apps: release_apps,
+    redeploy_config: redeploy_config
+  }, dep_changes_by_sha_tuple, app_dep_tree) do
     dep_changes = Map.get(dep_changes_by_sha_tuple, {current_sha, last_sha}) || []
 
     Enum.any?(release_apps, fn app_name ->
       if RedeployConfig.has_whitelist?(app_name, redeploy_config) do
         false
       else
-        dep_changes? =
-          Enum.any?(app_dep_tree[app_name] || [], fn app_dep_name ->
-            Enum.any?(dep_changes, &(&1 === app_dep_name))
-          end)
+        dep_changes? = Enum.any?(app_dep_tree[app_name] || [], fn app_dep_name ->
+          Enum.any?(dep_changes, &(&1 === app_dep_name))
+        end)
 
         if dep_changes? do
-          IO.puts(
-            to_string(
-              IO.ANSI.format([
-                :green,
-                "* #{release_app_app_name_string(release_app_name, app_name)} has dependency changes"
-              ])
-            )
-          )
+          IO.puts(to_string(IO.ANSI.format([
+            :green, "* #{release_app_app_name_string(release_app_name, app_name)} has dependency changes"
+          ])))
         end
 
         dep_changes?
@@ -280,24 +222,18 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
     end)
   end
 
-  defp release_has_local_dep_changes?(
-         %DeployEx.ReleaseUploader.State{
-           app_name: release_app_name,
-           sha: current_sha,
-           last_sha: last_sha,
-           release_apps: release_apps,
-           redeploy_config: redeploy_config
-         },
-         file_diffs_by_sha_tuple,
-         app_dep_tree
-       ) do
+  defp release_has_local_dep_changes?(%DeployEx.ReleaseUploader.State{
+    app_name: release_app_name,
+    sha: current_sha,
+    last_sha: last_sha,
+    release_apps: release_apps,
+    redeploy_config: redeploy_config
+  }, file_diffs_by_sha_tuple, app_dep_tree) do
     Enum.any?(release_apps, fn app_name ->
       file_diffs = Map.get(file_diffs_by_sha_tuple, {current_sha, last_sha}) || []
       filtered_diffs = RedeployConfig.filter_file_diffs(file_diffs, app_name, redeploy_config)
       app_deps = app_dep_tree[app_name] || []
-
-      changed_apps =
-        filtered_diffs
+      changed_apps = filtered_diffs
         |> Enum.flat_map(fn diff ->
           case Regex.run(~r/^apps\/([a-z0-9_]+)\//, diff) do
             [_, extracted_app] ->
@@ -311,19 +247,14 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
               end
           end
         end)
-        |> Enum.uniq()
+        |> Enum.uniq
 
       local_dep_changes? = Enum.any?(changed_apps) and Enum.any?(changed_apps, &(&1 in app_deps))
 
       if local_dep_changes? do
-        IO.puts(
-          to_string(
-            IO.ANSI.format([
-              :green,
-              "* #{release_app_app_name_string(release_app_name, app_name)} has local dependency changes"
-            ])
-          )
-        )
+        IO.puts(to_string(IO.ANSI.format([
+          :green, "* #{release_app_app_name_string(release_app_name, app_name)} has local dependency changes"
+        ])))
       end
 
       local_dep_changes?

--- a/lib/deploy_ex/release_uploader/update_validator.ex
+++ b/lib/deploy_ex/release_uploader/update_validator.ex
@@ -1,14 +1,19 @@
 defmodule DeployEx.ReleaseUploader.UpdateValidator do
-  alias DeployEx.ReleaseUploader.{RedeployConfig, UpdateValidator.MixDepsTreeParser, UpdateValidator.MixLockFileDiffParser}
+  alias DeployEx.ReleaseUploader.{
+    RedeployConfig,
+    UpdateValidator.MixDepsTreeParser,
+    UpdateValidator.MixLockFileDiffParser
+  }
 
   @max_git_diff_concurrency 2
 
   def filter_changed(release_states) do
     with {:ok, file_diffs_by_sha_tuple} <- load_file_diffs(release_states),
-         {:ok, {
-           {invalid_release_states, release_states},
-           file_diffs_by_sha_tuple
-         }} <- split_invalid_releases(release_states, file_diffs_by_sha_tuple),
+         {:ok,
+          {
+            {invalid_release_states, release_states},
+            file_diffs_by_sha_tuple
+          }} <- split_invalid_releases(release_states, file_diffs_by_sha_tuple),
          {:ok, dep_changes_by_sha_tuple} <- load_dep_changes(file_diffs_by_sha_tuple),
          {:ok, app_dep_tree} <- MixDepsTreeParser.load_app_dep_tree() do
       filter_changed(
@@ -22,73 +27,80 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
   end
 
   def filter_changed(
-    invalid_release_states,
-    release_states,
-    file_diffs_by_sha_tuple,
-    dep_changes_by_sha_tuple,
-    app_dep_tree
-  ) do
-    {never_uploaded_releases, release_states} = Enum.split_with(
-      release_states,
-      &is_nil(&1.last_sha)
-    )
+        invalid_release_states,
+        release_states,
+        file_diffs_by_sha_tuple,
+        dep_changes_by_sha_tuple,
+        app_dep_tree
+      ) do
+    {never_uploaded_releases, release_states} =
+      Enum.split_with(
+        release_states,
+        &is_nil(&1.last_sha)
+      )
 
-    {:ok, never_uploaded_releases ++ invalid_release_states ++ Enum.filter(release_states, fn release_state ->
-      release_has_code_changes?(release_state, file_diffs_by_sha_tuple) or
-      release_has_local_dep_changes?(release_state, file_diffs_by_sha_tuple, app_dep_tree) or
-      release_has_dep_changes?(release_state, dep_changes_by_sha_tuple, app_dep_tree)
-    end)}
+    {:ok,
+     never_uploaded_releases ++
+       invalid_release_states ++
+       Enum.filter(release_states, fn release_state ->
+         release_has_code_changes?(release_state, file_diffs_by_sha_tuple) or
+           release_has_local_dep_changes?(release_state, file_diffs_by_sha_tuple, app_dep_tree) or
+           release_has_dep_changes?(release_state, dep_changes_by_sha_tuple, app_dep_tree)
+       end)}
   end
 
   def split_invalid_releases(release_states, file_diffs_by_sha_tuple) do
-    split_release_states = Enum.split_with(
-      release_states,
-      &uploaded_release_invalid?(&1, file_diffs_by_sha_tuple)
-    )
+    split_release_states =
+      Enum.split_with(
+        release_states,
+        &uploaded_release_invalid?(&1, file_diffs_by_sha_tuple)
+      )
 
-    file_diffs_by_sha_tuple = file_diffs_by_sha_tuple
+    file_diffs_by_sha_tuple =
+      file_diffs_by_sha_tuple
       |> Enum.reject(fn
         {_, [:invalid]} -> true
         _ -> false
       end)
-      |> Map.new
+      |> Map.new()
 
     {:ok, {split_release_states, file_diffs_by_sha_tuple}}
   end
 
   def load_file_diffs(states) do
-    from_to_shas = states |> Enum.map(&{&1.sha, &1.last_sha}) |> Enum.uniq
+    from_to_shas = states |> Enum.map(&{&1.sha, &1.last_sha}) |> Enum.uniq()
 
     with {:ok, file_diffs} <- file_diffs_between(from_to_shas) do
       file_diffs
-        |> Enum.reject(fn
-          {_sha_tuple, [""]} -> true
-          {_sha_tuple, []} -> true
-          {_sha_tuple, _} -> false
-        end)
-        |> Map.new
-        |> then(&{:ok, &1})
+      |> Enum.reject(fn
+        {_sha_tuple, [""]} -> true
+        {_sha_tuple, []} -> true
+        {_sha_tuple, _} -> false
+      end)
+      |> Map.new()
+      |> then(&{:ok, &1})
     end
   end
 
   def load_dep_changes(file_diffs_by_sha_tuple) do
-    res = file_diffs_by_sha_tuple
+    res =
+      file_diffs_by_sha_tuple
       |> filter_file_diffs_for_deps_update
       |> Task.async_stream(
         &MixLockFileDiffParser.git_diff_mix_lock/1,
         max_concurrency: @max_git_diff_concurrency
       )
-      |> DeployEx.Utils.reduce_task_status_tuples
+      |> DeployEx.Utils.reduce_task_status_tuples()
 
     with {:ok, file_diffs_by_sha_tuple} <- res do
       file_diffs_by_sha_tuple
-        |> Enum.reject(fn
-          {_sha_tuple, [""]} -> true
-          {_sha_tuple, []} -> true
-          _ -> false
-        end)
-        |> Map.new
-        |> then(&{:ok, &1})
+      |> Enum.reject(fn
+        {_sha_tuple, [""]} -> true
+        {_sha_tuple, []} -> true
+        _ -> false
+      end)
+      |> Map.new()
+      |> then(&{:ok, &1})
     end
   end
 
@@ -100,63 +112,78 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
 
   defp file_diffs_between(from_to_shas) do
     from_to_shas
-      |> Task.async_stream(fn {current_sha, last_sha} = sha_tuple ->
+    |> Task.async_stream(
+      fn {current_sha, last_sha} = sha_tuple ->
         with {:ok, file_diffs} <- git_diff_files_between(current_sha, last_sha) do
           {:ok, {sha_tuple, file_diffs}}
         end
-      end, max_concurrency: @max_git_diff_concurrency)
-      |> DeployEx.Utils.reduce_task_status_tuples
+      end,
+      max_concurrency: @max_git_diff_concurrency
+    )
+    |> DeployEx.Utils.reduce_task_status_tuples()
   end
 
   defp git_diff_files_between(current_sha, last_sha) do
     case System.shell("git diff --name-only #{current_sha}..#{last_sha} --") do
-      {output, 0} -> {:ok, output |> String.trim_trailing("\n") |> String.split("\n")}
-      {"", 128} -> {:ok, [:invalid]}
+      {output, 0} ->
+        {:ok, output |> String.trim_trailing("\n") |> String.split("\n")}
 
-      {output, code} -> {:error, ErrorMessage.failed_dependency(
-        "couldn't run git diff --name-only",
-        %{output: output, code: code}
-      )}
+      {"", 128} ->
+        {:ok, [:invalid]}
+
+      {output, code} ->
+        {:error,
+         ErrorMessage.failed_dependency(
+           "couldn't run git diff --name-only",
+           %{output: output, code: code}
+         )}
     end
   end
 
-  defp uploaded_release_invalid?(%DeployEx.ReleaseUploader.State{
-    sha: current_sha,
-    last_sha: last_sha
-  }, file_diffs_by_sha_tuple) do
+  defp uploaded_release_invalid?(
+         %DeployEx.ReleaseUploader.State{
+           sha: current_sha,
+           last_sha: last_sha
+         },
+         file_diffs_by_sha_tuple
+       ) do
     Map.get(file_diffs_by_sha_tuple, {current_sha, last_sha}) === [:invalid]
   end
 
-  defp release_has_code_changes?(%DeployEx.ReleaseUploader.State{
-    app_name: release_app_name,
-    sha: current_sha,
-    last_sha: last_sha,
-    release_apps: release_apps,
-    redeploy_config: redeploy_config
-  }, file_diffs_by_sha_tuple) do
+  defp release_has_code_changes?(
+         %DeployEx.ReleaseUploader.State{
+           app_name: release_app_name,
+           sha: current_sha,
+           last_sha: last_sha,
+           release_apps: release_apps,
+           redeploy_config: redeploy_config
+         },
+         file_diffs_by_sha_tuple
+       ) do
     file_diffs = Map.get(file_diffs_by_sha_tuple, {current_sha, last_sha}) || []
 
-    Enum.any?(file_diffs) && Enum.any?(release_apps, fn app_name ->
-      filtered_diffs = RedeployConfig.filter_file_diffs(file_diffs, app_name, redeploy_config)
+    Enum.any?(file_diffs) &&
+      Enum.any?(release_apps, fn app_name ->
+        filtered_diffs = RedeployConfig.filter_file_diffs(file_diffs, app_name, redeploy_config)
 
-      root_mix_exs_change? = Enum.any?(filtered_diffs, &(&1 === "mix.exs"))
-      code_change? = Enum.any?(filtered_diffs, &file_part_of_app(&1, app_name))
-      config_change? = Enum.any?(filtered_diffs, &config_file?(&1))
-      rel_file_change? = Enum.any?(filtered_diffs, &rel_file?(&1))
+        root_mix_exs_change? = Enum.any?(filtered_diffs, &(&1 === "mix.exs"))
+        code_change? = Enum.any?(filtered_diffs, &file_part_of_app(&1, app_name))
+        config_change? = Enum.any?(filtered_diffs, &config_file?(&1))
+        rel_file_change? = Enum.any?(filtered_diffs, &rel_file?(&1))
 
-      changes = if config_change?, do: ["config"], else: []
-      changes = if root_mix_exs_change?, do: ["root mix.exs" | changes], else: changes
-      changes = if code_change?, do: ["code" | changes], else: changes
-      changes = if rel_file_change?, do: ["release file" | changes], else: changes
+        changes = if config_change?, do: ["config"], else: []
+        changes = if root_mix_exs_change?, do: ["root mix.exs" | changes], else: changes
+        changes = if code_change?, do: ["code" | changes], else: changes
+        changes = if rel_file_change?, do: ["release file" | changes], else: changes
 
-      changes? = Enum.any?(changes)
+        changes? = Enum.any?(changes)
 
-      if changes? do
-        log_app_change(changes, release_app_app_name_string(release_app_name, app_name))
-      end
+        if changes? do
+          log_app_change(changes, release_app_app_name_string(release_app_name, app_name))
+        end
 
-      changes?
-    end)
+        changes?
+      end)
   end
 
   def log_app_change([], _) do
@@ -164,25 +191,47 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
   end
 
   def log_app_change([change], app_name) do
-    IO.puts(to_string(IO.ANSI.format([
-      :green, "* #{change} changes detected ", :reset, app_name
-    ])))
+    IO.puts(
+      to_string(
+        IO.ANSI.format([
+          :green,
+          "* #{change} changes detected ",
+          :reset,
+          app_name
+        ])
+      )
+    )
   end
 
   def log_app_change([change_a, change_b], app_name) do
-    IO.puts(to_string(IO.ANSI.format([
-      :green, "* #{change_a} & #{change_b} changes detected ", :reset, app_name
-    ])))
+    IO.puts(
+      to_string(
+        IO.ANSI.format([
+          :green,
+          "* #{change_a} & #{change_b} changes detected ",
+          :reset,
+          app_name
+        ])
+      )
+    )
   end
 
   def log_app_change([change_a | changes], app_name) do
-    IO.puts(to_string(IO.ANSI.format([
-      :green, "* #{Enum.join(changes, ", ")} & #{change_a} changes detected ", :reset, app_name
-    ])))
+    IO.puts(
+      to_string(
+        IO.ANSI.format([
+          :green,
+          "* #{Enum.join(changes, ", ")} & #{change_a} changes detected ",
+          :reset,
+          app_name
+        ])
+      )
+    )
   end
 
   defp file_part_of_app(diff, app_name) do
-    diff =~ ~r/^apps\/#{app_name}\//
+    diff =~ ~r/^apps\/#{app_name}\// or
+      (DeployEx.ProjectContext.type() === :single_app and diff =~ ~r/^(lib|test|priv)\//)
   end
 
   defp rel_file?(diff) do
@@ -193,27 +242,37 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
     diff =~ ~r/config\/[a-z0-9A-Z\.-_]+.exs/
   end
 
-  defp release_has_dep_changes?(%DeployEx.ReleaseUploader.State{
-    app_name: release_app_name,
-    sha: current_sha,
-    last_sha: last_sha,
-    release_apps: release_apps,
-    redeploy_config: redeploy_config
-  }, dep_changes_by_sha_tuple, app_dep_tree) do
+  defp release_has_dep_changes?(
+         %DeployEx.ReleaseUploader.State{
+           app_name: release_app_name,
+           sha: current_sha,
+           last_sha: last_sha,
+           release_apps: release_apps,
+           redeploy_config: redeploy_config
+         },
+         dep_changes_by_sha_tuple,
+         app_dep_tree
+       ) do
     dep_changes = Map.get(dep_changes_by_sha_tuple, {current_sha, last_sha}) || []
 
     Enum.any?(release_apps, fn app_name ->
       if RedeployConfig.has_whitelist?(app_name, redeploy_config) do
         false
       else
-        dep_changes? = Enum.any?(app_dep_tree[app_name] || [], fn app_dep_name ->
-          Enum.any?(dep_changes, &(&1 === app_dep_name))
-        end)
+        dep_changes? =
+          Enum.any?(app_dep_tree[app_name] || [], fn app_dep_name ->
+            Enum.any?(dep_changes, &(&1 === app_dep_name))
+          end)
 
         if dep_changes? do
-          IO.puts(to_string(IO.ANSI.format([
-            :green, "* #{release_app_app_name_string(release_app_name, app_name)} has dependency changes"
-          ])))
+          IO.puts(
+            to_string(
+              IO.ANSI.format([
+                :green,
+                "* #{release_app_app_name_string(release_app_name, app_name)} has dependency changes"
+              ])
+            )
+          )
         end
 
         dep_changes?
@@ -221,25 +280,50 @@ defmodule DeployEx.ReleaseUploader.UpdateValidator do
     end)
   end
 
-  defp release_has_local_dep_changes?(%DeployEx.ReleaseUploader.State{
-    app_name: release_app_name,
-    sha: current_sha,
-    last_sha: last_sha,
-    release_apps: release_apps,
-    redeploy_config: redeploy_config
-  }, file_diffs_by_sha_tuple, app_dep_tree) do
+  defp release_has_local_dep_changes?(
+         %DeployEx.ReleaseUploader.State{
+           app_name: release_app_name,
+           sha: current_sha,
+           last_sha: last_sha,
+           release_apps: release_apps,
+           redeploy_config: redeploy_config
+         },
+         file_diffs_by_sha_tuple,
+         app_dep_tree
+       ) do
     Enum.any?(release_apps, fn app_name ->
       file_diffs = Map.get(file_diffs_by_sha_tuple, {current_sha, last_sha}) || []
       filtered_diffs = RedeployConfig.filter_file_diffs(file_diffs, app_name, redeploy_config)
       app_deps = app_dep_tree[app_name] || []
-      changed_apps = Enum.map(filtered_diffs, &String.replace(&1, ~r/^apps\/([a-z0-9_]+)\/.*/, "\\1"))
+
+      changed_apps =
+        filtered_diffs
+        |> Enum.flat_map(fn diff ->
+          case Regex.run(~r/^apps\/([a-z0-9_]+)\//, diff) do
+            [_, extracted_app] ->
+              [extracted_app]
+
+            nil ->
+              if DeployEx.ProjectContext.type() === :single_app do
+                DeployEx.ProjectContext.apps()
+              else
+                []
+              end
+          end
+        end)
+        |> Enum.uniq()
 
       local_dep_changes? = Enum.any?(changed_apps) and Enum.any?(changed_apps, &(&1 in app_deps))
 
       if local_dep_changes? do
-        IO.puts(to_string(IO.ANSI.format([
-          :green, "* #{release_app_app_name_string(release_app_name, app_name)} has local dependency changes"
-        ])))
+        IO.puts(
+          to_string(
+            IO.ANSI.format([
+              :green,
+              "* #{release_app_app_name_string(release_app_name, app_name)} has local dependency changes"
+            ])
+          )
+        )
       end
 
       local_dep_changes?

--- a/lib/mix/deploy_ex_helpers.ex
+++ b/lib/mix/deploy_ex_helpers.ex
@@ -1,56 +1,55 @@
 defmodule DeployExHelpers do
   @server_ssh_pem_path "./_build/.server-ssh"
 
-  def project_apps, do: File.ls!(Mix.Project.get().project()[:apps_path])
+  def project_apps, do: DeployEx.ProjectContext.apps()
 
   def release_apps_by_release_name do
     with {:ok, releases} <- fetch_mix_releases() do
-      {:ok, Enum.map(releases, fn {key, opts} ->
-        {key, opts[:applications]
-          |> Keyword.keys
+      {:ok,
+       Enum.map(releases, fn {key, opts} ->
+         {key,
+          opts[:applications]
+          |> Keyword.keys()
           |> Enum.map(&to_string/1)
           |> Enum.filter(&(&1 in DeployExHelpers.project_apps()))}
-      end)}
+       end)}
     end
   end
 
   def redeploy_config_by_release_name do
     with {:ok, releases} <- fetch_mix_releases() do
-      {:ok, Enum.map(releases, fn {key, opts} ->
-        deploy_ex_opts = opts[:deploy_ex] || []
+      {:ok,
+       Enum.map(releases, fn {key, opts} ->
+         deploy_ex_opts = opts[:deploy_ex] || []
 
-        {key, DeployEx.ReleaseUploader.RedeployConfig.from_keyword(deploy_ex_opts[:redeploy_config])}
-      end)}
+         {key,
+          DeployEx.ReleaseUploader.RedeployConfig.from_keyword(deploy_ex_opts[:redeploy_config])}
+       end)}
     end
   end
 
-  def project_name, do: Mix.Project.get() |> Module.split |> hd
+  def project_name, do: Mix.Project.get() |> Module.split() |> hd
   def underscored_project_name, do: Macro.underscore(project_name())
   def kebab_project_name, do: String.replace(underscored_project_name(), "_", "-")
   def title_case_project_name, do: DeployEx.Utils.upper_title_case(underscored_project_name())
 
-  def check_in_umbrella do
-    if Mix.Project.umbrella?() do
-      :ok
-    else
-      {:error, ErrorMessage.bad_request("must be in umbrella root")}
-    end
-  end
+  def check_valid_project, do: DeployEx.ProjectContext.check_valid_project()
 
   def priv_file(priv_subdirectory) do
     :deploy_ex
-      |> :code.priv_dir
-      |> Path.join(priv_subdirectory)
+    |> :code.priv_dir()
+    |> Path.join(priv_subdirectory)
   end
 
   def write_template(template_path, output_path, variables, opts) do
     output_file = EEx.eval_file(template_path, assigns: variables)
 
-    opts = if File.exists?(output_path) do
-      [{:message, [:green, "* rewriting ", :reset, output_path]} | opts]
-    else
-      opts
-    end
+    opts =
+      if File.exists?(output_path) do
+        [{:message, [:green, "* rewriting ", :reset, output_path]} | opts]
+      else
+        opts
+      end
 
     DeployExHelpers.write_file(output_path, output_file, opts)
   end
@@ -75,23 +74,20 @@ defmodule DeployExHelpers do
 
   def check_file_exists!(file_path) do
     if !File.exists?(file_path) do
-      raise to_string(IO.ANSI.format([
-        :red, "Cannot find ",
-        :bright, "#{file_path}", :reset
-      ]))
+      raise to_string(
+              IO.ANSI.format([
+                :red,
+                "Cannot find ",
+                :bright,
+                "#{file_path}",
+                :reset
+              ])
+            )
     end
   end
 
   def fetch_mix_releases do
-    case Mix.Project.get() do
-      nil -> {:error, ErrorMessage.not_found("couldn't find mix project")}
-      project ->
-        if project.project()[:releases] do
-          {:ok, project.project()[:releases]}
-        else
-          {:error, ErrorMessage.not_found("no release found for #{inspect project}")}
-        end
-    end
+    DeployEx.ProjectContext.releases()
   end
 
   def fetch_mix_release_names do
@@ -130,10 +126,12 @@ defmodule DeployExHelpers do
 
     cond do
       except_given? and only_given? ->
-        raise to_string(IO.ANSI.format([
-          :red,
-          "Cannot specify both only and except arguments"
-        ]))
+        raise to_string(
+                IO.ANSI.format([
+                  :red,
+                  "Cannot specify both only and except arguments"
+                ])
+              )
 
       only_given? ->
         app_name = Path.basename(playbook)
@@ -162,7 +160,7 @@ defmodule DeployExHelpers do
   end
 
   def find_project_name(releases, [app_name]) do
-    case releases |> Keyword.keys |> Enum.find(&(to_string(&1) =~ app_name)) do
+    case releases |> Keyword.keys() |> Enum.find(&(to_string(&1) =~ app_name)) do
       nil -> {:ok, app_name}
       app_name -> {:ok, to_string(app_name)}
     end
@@ -170,7 +168,8 @@ defmodule DeployExHelpers do
 
   def run_ssh_command_with_return(terraform_directory, pem, app_name, command, opts) do
     with {:ok, pem_file_path} <- DeployEx.Terraform.find_pem_file(terraform_directory, pem),
-         {:ok, instance_details} <- DeployEx.AwsMachine.find_instance_details(project_name(), app_name, opts) do
+         {:ok, instance_details} <-
+           DeployEx.AwsMachine.find_instance_details(project_name(), app_name, opts) do
       pem_rsa_path = Path.join(@server_ssh_pem_path, "id_rsa")
 
       if not File.exists?(pem_rsa_path) do
@@ -181,13 +180,14 @@ defmodule DeployExHelpers do
       File.cp!(pem_file_path, pem_rsa_path)
       File.chmod!(pem_rsa_path, 0o600)
 
-      res = instance_details
+      res =
+        instance_details
         |> prompt_for_instance_choice(true)
         |> Enum.map(fn ip_address ->
           Mix.shell().info([:yellow, "Running '#{command}' on #{ip_address}"])
           DeployEx.SSH.run_command(ip_address, opts[:port] || 22, pem_rsa_path, command)
         end)
-        |> DeployEx.Utils.reduce_status_tuples
+        |> DeployEx.Utils.reduce_status_tuples()
 
       with {:error, [error]} <- res do
         {:error, error}
@@ -197,7 +197,8 @@ defmodule DeployExHelpers do
 
   def run_ssh_command(terraform_directory, pem, app_name, command, opts) do
     with {:ok, pem_file_path} <- DeployEx.Terraform.find_pem_file(terraform_directory, pem),
-         {:ok, instance_details} <- DeployEx.AwsMachine.find_instance_details(project_name(), app_name, opts) do
+         {:ok, instance_details} <-
+           DeployEx.AwsMachine.find_instance_details(project_name(), app_name, opts) do
       pem_rsa_path = Path.join(@server_ssh_pem_path, "id_rsa")
 
       if not File.exists?(pem_rsa_path) do
@@ -209,15 +210,15 @@ defmodule DeployExHelpers do
       File.chmod!(pem_rsa_path, 0o600)
 
       instance_details
-        |> prompt_for_instance_choice(true)
-        |> Enum.reduce_while(:ok, fn instance_ip, :ok ->
-          Mix.shell().info([:yellow, "Running #{command} on #{instance_ip}"])
+      |> prompt_for_instance_choice(true)
+      |> Enum.reduce_while(:ok, fn instance_ip, :ok ->
+        Mix.shell().info([:yellow, "Running #{command} on #{instance_ip}"])
 
-          case DeployEx.SSH.run_command(instance_ip, opts[:port] || 22, pem_rsa_path, command) do
-            {:ok, _} -> {:cont, :ok}
-            {:error, _} = error -> {:halt, error}
-          end
-        end)
+        case DeployEx.SSH.run_command(instance_ip, opts[:port] || 22, pem_rsa_path, command) do
+          {:ok, _} -> {:cont, :ok}
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
     end
   end
 
@@ -238,9 +239,9 @@ defmodule DeployExHelpers do
     ip_map = Map.new(instance_details, &{&1.name, &1.ipv6 || &1.ip})
 
     instance_details
-      |> Enum.map(&(&1.name))
-      |> DeployExHelpers.prompt_for_choice(select_all?)
-      |> Enum.map(&ip_map[&1])
+    |> Enum.map(& &1.name)
+    |> DeployExHelpers.prompt_for_choice(select_all?)
+    |> Enum.map(&ip_map[&1])
   end
 
   def find_similar_strings(items, target, opts \\ []) do
@@ -254,7 +255,9 @@ defmodule DeployExHelpers do
       distance = String.jaro_distance(target, extracted)
       {item, extracted, distance}
     end)
-    |> Enum.filter(fn {_, extracted, distance} -> extracted !== "" and distance >= min_distance end)
+    |> Enum.filter(fn {_, extracted, distance} ->
+      extracted !== "" and distance >= min_distance
+    end)
     |> Enum.sort_by(fn {_, _, distance} -> distance end, :desc)
     |> Enum.take(limit)
   end
@@ -286,6 +289,7 @@ defmodule DeployExHelpers do
   end
 
   defp humanize_timestamp(nil), do: "unknown date"
+
   defp humanize_timestamp(timestamp) do
     case Integer.parse(timestamp) do
       {unix_ts, _} ->
@@ -293,7 +297,9 @@ defmodule DeployExHelpers do
           {:ok, datetime} -> humanize_datetime(datetime)
           _ -> timestamp
         end
-      :error -> timestamp
+
+      :error ->
+        timestamp
     end
   end
 
@@ -318,14 +324,20 @@ defmodule DeployExHelpers do
       _ ->
         Mix.shell().info([:yellow, "Ansible not found, installing..."])
 
-        case System.cmd("pip3", ["install", "--user", "ansible", "boto3", "botocore"], stderr_to_stdout: true) do
+        case System.cmd("pip3", ["install", "--user", "ansible", "boto3", "botocore"],
+               stderr_to_stdout: true
+             ) do
           {_, 0} ->
             Mix.shell().info([:green, "✓ Ansible installed successfully"])
             :ok
 
           {error, _} ->
             Mix.shell().error("Failed to install ansible: #{error}")
-            Mix.shell().info("Please install ansible manually: pip3 install ansible boto3 botocore")
+
+            Mix.shell().info(
+              "Please install ansible manually: pip3 install ansible boto3 botocore"
+            )
+
             {:error, "Ansible installation failed"}
         end
     end

--- a/lib/mix/deploy_ex_helpers.ex
+++ b/lib/mix/deploy_ex_helpers.ex
@@ -5,51 +5,50 @@ defmodule DeployExHelpers do
 
   def release_apps_by_release_name do
     with {:ok, releases} <- fetch_mix_releases() do
-      {:ok,
-       Enum.map(releases, fn {key, opts} ->
-         {key,
-          opts[:applications]
-          |> Keyword.keys()
+      {:ok, Enum.map(releases, fn {key, opts} ->
+        {key, opts[:applications]
+          |> Keyword.keys
           |> Enum.map(&to_string/1)
           |> Enum.filter(&(&1 in DeployExHelpers.project_apps()))}
-       end)}
+      end)}
     end
   end
 
   def redeploy_config_by_release_name do
     with {:ok, releases} <- fetch_mix_releases() do
-      {:ok,
-       Enum.map(releases, fn {key, opts} ->
-         deploy_ex_opts = opts[:deploy_ex] || []
+      {:ok, Enum.map(releases, fn {key, opts} ->
+        deploy_ex_opts = opts[:deploy_ex] || []
 
-         {key,
-          DeployEx.ReleaseUploader.RedeployConfig.from_keyword(deploy_ex_opts[:redeploy_config])}
-       end)}
+        {key, DeployEx.ReleaseUploader.RedeployConfig.from_keyword(deploy_ex_opts[:redeploy_config])}
+      end)}
     end
   end
 
-  def project_name, do: Mix.Project.get() |> Module.split() |> hd
+  def project_name, do: Mix.Project.get() |> Module.split |> hd
   def underscored_project_name, do: Macro.underscore(project_name())
   def kebab_project_name, do: String.replace(underscored_project_name(), "_", "-")
   def title_case_project_name, do: DeployEx.Utils.upper_title_case(underscored_project_name())
 
   def check_valid_project, do: DeployEx.ProjectContext.check_valid_project()
 
-  def priv_file(priv_subdirectory) do
-    :deploy_ex
-    |> :code.priv_dir()
-    |> Path.join(priv_subdirectory)
+  def priv_folder(priv_subdirectory) do
+    local_path = Path.join(DeployEx.Config.deploy_folder(), priv_subdirectory)
+
+    if File.exists?(local_path) do
+      local_path
+    else
+      :deploy_ex |> :code.priv_dir() |> Path.join(priv_subdirectory)
+    end
   end
 
   def write_template(template_path, output_path, variables, opts) do
     output_file = EEx.eval_file(template_path, assigns: variables)
 
-    opts =
-      if File.exists?(output_path) do
-        [{:message, [:green, "* rewriting ", :reset, output_path]} | opts]
-      else
-        opts
-      end
+    opts = if File.exists?(output_path) do
+      [{:message, [:green, "* rewriting ", :reset, output_path]} | opts]
+    else
+      opts
+    end
 
     DeployExHelpers.write_file(output_path, output_file, opts)
   end
@@ -74,15 +73,10 @@ defmodule DeployExHelpers do
 
   def check_file_exists!(file_path) do
     if !File.exists?(file_path) do
-      raise to_string(
-              IO.ANSI.format([
-                :red,
-                "Cannot find ",
-                :bright,
-                "#{file_path}",
-                :reset
-              ])
-            )
+      raise to_string(IO.ANSI.format([
+        :red, "Cannot find ",
+        :bright, "#{file_path}", :reset
+      ]))
     end
   end
 
@@ -126,12 +120,10 @@ defmodule DeployExHelpers do
 
     cond do
       except_given? and only_given? ->
-        raise to_string(
-                IO.ANSI.format([
-                  :red,
-                  "Cannot specify both only and except arguments"
-                ])
-              )
+        raise to_string(IO.ANSI.format([
+          :red,
+          "Cannot specify both only and except arguments"
+        ]))
 
       only_given? ->
         app_name = Path.basename(playbook)
@@ -160,7 +152,7 @@ defmodule DeployExHelpers do
   end
 
   def find_project_name(releases, [app_name]) do
-    case releases |> Keyword.keys() |> Enum.find(&(to_string(&1) =~ app_name)) do
+    case releases |> Keyword.keys |> Enum.find(&(to_string(&1) =~ app_name)) do
       nil -> {:ok, app_name}
       app_name -> {:ok, to_string(app_name)}
     end
@@ -168,8 +160,7 @@ defmodule DeployExHelpers do
 
   def run_ssh_command_with_return(terraform_directory, pem, app_name, command, opts) do
     with {:ok, pem_file_path} <- DeployEx.Terraform.find_pem_file(terraform_directory, pem),
-         {:ok, instance_details} <-
-           DeployEx.AwsMachine.find_instance_details(project_name(), app_name, opts) do
+         {:ok, instance_details} <- DeployEx.AwsMachine.find_instance_details(project_name(), app_name, opts) do
       pem_rsa_path = Path.join(@server_ssh_pem_path, "id_rsa")
 
       if not File.exists?(pem_rsa_path) do
@@ -180,14 +171,13 @@ defmodule DeployExHelpers do
       File.cp!(pem_file_path, pem_rsa_path)
       File.chmod!(pem_rsa_path, 0o600)
 
-      res =
-        instance_details
+      res = instance_details
         |> prompt_for_instance_choice(true)
         |> Enum.map(fn ip_address ->
           Mix.shell().info([:yellow, "Running '#{command}' on #{ip_address}"])
           DeployEx.SSH.run_command(ip_address, opts[:port] || 22, pem_rsa_path, command)
         end)
-        |> DeployEx.Utils.reduce_status_tuples()
+        |> DeployEx.Utils.reduce_status_tuples
 
       with {:error, [error]} <- res do
         {:error, error}
@@ -197,8 +187,7 @@ defmodule DeployExHelpers do
 
   def run_ssh_command(terraform_directory, pem, app_name, command, opts) do
     with {:ok, pem_file_path} <- DeployEx.Terraform.find_pem_file(terraform_directory, pem),
-         {:ok, instance_details} <-
-           DeployEx.AwsMachine.find_instance_details(project_name(), app_name, opts) do
+         {:ok, instance_details} <- DeployEx.AwsMachine.find_instance_details(project_name(), app_name, opts) do
       pem_rsa_path = Path.join(@server_ssh_pem_path, "id_rsa")
 
       if not File.exists?(pem_rsa_path) do
@@ -210,15 +199,15 @@ defmodule DeployExHelpers do
       File.chmod!(pem_rsa_path, 0o600)
 
       instance_details
-      |> prompt_for_instance_choice(true)
-      |> Enum.reduce_while(:ok, fn instance_ip, :ok ->
-        Mix.shell().info([:yellow, "Running #{command} on #{instance_ip}"])
+        |> prompt_for_instance_choice(true)
+        |> Enum.reduce_while(:ok, fn instance_ip, :ok ->
+          Mix.shell().info([:yellow, "Running #{command} on #{instance_ip}"])
 
-        case DeployEx.SSH.run_command(instance_ip, opts[:port] || 22, pem_rsa_path, command) do
-          {:ok, _} -> {:cont, :ok}
-          {:error, _} = error -> {:halt, error}
-        end
-      end)
+          case DeployEx.SSH.run_command(instance_ip, opts[:port] || 22, pem_rsa_path, command) do
+            {:ok, _} -> {:cont, :ok}
+            {:error, _} = error -> {:halt, error}
+          end
+        end)
     end
   end
 
@@ -239,9 +228,9 @@ defmodule DeployExHelpers do
     ip_map = Map.new(instance_details, &{&1.name, &1.ipv6 || &1.ip})
 
     instance_details
-    |> Enum.map(& &1.name)
-    |> DeployExHelpers.prompt_for_choice(select_all?)
-    |> Enum.map(&ip_map[&1])
+      |> Enum.map(&(&1.name))
+      |> DeployExHelpers.prompt_for_choice(select_all?)
+      |> Enum.map(&ip_map[&1])
   end
 
   def find_similar_strings(items, target, opts \\ []) do
@@ -255,9 +244,7 @@ defmodule DeployExHelpers do
       distance = String.jaro_distance(target, extracted)
       {item, extracted, distance}
     end)
-    |> Enum.filter(fn {_, extracted, distance} ->
-      extracted !== "" and distance >= min_distance
-    end)
+    |> Enum.filter(fn {_, extracted, distance} -> extracted !== "" and distance >= min_distance end)
     |> Enum.sort_by(fn {_, _, distance} -> distance end, :desc)
     |> Enum.take(limit)
   end
@@ -289,7 +276,6 @@ defmodule DeployExHelpers do
   end
 
   defp humanize_timestamp(nil), do: "unknown date"
-
   defp humanize_timestamp(timestamp) do
     case Integer.parse(timestamp) do
       {unix_ts, _} ->
@@ -297,9 +283,7 @@ defmodule DeployExHelpers do
           {:ok, datetime} -> humanize_datetime(datetime)
           _ -> timestamp
         end
-
-      :error ->
-        timestamp
+      :error -> timestamp
     end
   end
 
@@ -324,20 +308,14 @@ defmodule DeployExHelpers do
       _ ->
         Mix.shell().info([:yellow, "Ansible not found, installing..."])
 
-        case System.cmd("pip3", ["install", "--user", "ansible", "boto3", "botocore"],
-               stderr_to_stdout: true
-             ) do
+        case System.cmd("pip3", ["install", "--user", "ansible", "boto3", "botocore"], stderr_to_stdout: true) do
           {_, 0} ->
             Mix.shell().info([:green, "✓ Ansible installed successfully"])
             :ok
 
           {error, _} ->
             Mix.shell().error("Failed to install ansible: #{error}")
-
-            Mix.shell().info(
-              "Please install ansible manually: pip3 install ansible boto3 botocore"
-            )
-
+            Mix.shell().info("Please install ansible manually: pip3 install ansible boto3 botocore")
             {:error, "Ansible installation failed"}
         end
     end

--- a/lib/mix/tasks/ansible.build.ex
+++ b/lib/mix/tasks/ansible.build.ex
@@ -91,7 +91,7 @@ defmodule Mix.Tasks.Ansible.Build do
       Mix.shell().info([:green, "* copying ansible into ", :reset, directory])
 
       "ansible"
-        |> DeployExHelpers.priv_file()
+        |> DeployExHelpers.priv_folder()
         |> File.cp_r!(directory)
 
       File.rm!(Path.join(directory, "group_vars/all.yaml.eex"))
@@ -168,7 +168,7 @@ defmodule Mix.Tasks.Ansible.Build do
       }
 
       DeployExHelpers.write_template(
-        DeployExHelpers.priv_file("ansible/group_vars/all.yaml.eex"),
+        DeployExHelpers.priv_folder("ansible/group_vars/all.yaml.eex"),
         opts[:group_vars_file],
         variables,
         opts
@@ -193,7 +193,7 @@ defmodule Mix.Tasks.Ansible.Build do
       }
 
       DeployExHelpers.write_template(
-        DeployExHelpers.priv_file("ansible/ansible.cfg.eex"),
+        DeployExHelpers.priv_folder("ansible/ansible.cfg.eex"),
         opts[:config_file],
         variables,
         opts
@@ -213,7 +213,7 @@ defmodule Mix.Tasks.Ansible.Build do
     }
 
     DeployExHelpers.write_template(
-      DeployExHelpers.priv_file("ansible/aws_ec2.yaml.eex"),
+      DeployExHelpers.priv_folder("ansible/aws_ec2.yaml.eex"),
       opts[:hosts_file],
       variables,
       opts
@@ -300,7 +300,7 @@ defmodule Mix.Tasks.Ansible.Build do
   end
 
   defp build_host_playbook(app_name, opts) do
-    host_playbook_template_path = DeployExHelpers.priv_file("ansible/app_playbook.yaml.eex")
+    host_playbook_template_path = DeployExHelpers.priv_folder("ansible/app_playbook.yaml.eex")
     host_playbook_path = Path.join(opts[:directory], "playbooks/#{app_name}.yaml")
 
     variables = %{
@@ -320,7 +320,7 @@ defmodule Mix.Tasks.Ansible.Build do
   end
 
   defp build_host_setup_playbook(app_name, opts) do
-    setup_playbook_path = DeployExHelpers.priv_file("ansible/app_setup_playbook.yaml.eex")
+    setup_playbook_path = DeployExHelpers.priv_folder("ansible/app_setup_playbook.yaml.eex")
     setup_host_playbook = Path.join(opts[:directory], "setup/#{app_name}.yaml")
 
     variables = %{

--- a/lib/mix/tasks/ansible.build.ex
+++ b/lib/mix/tasks/ansible.build.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Ansible.Build do
       |> Keyword.put_new(:aws_release_bucket, Config.aws_release_bucket())
       |> Keyword.put_new(:aws_region, Config.aws_region())
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          :ok <- ensure_ansible_directory_exists(opts[:directory], opts),
          :ok <- create_ansible_hosts_file(opts),
          :ok <- create_ansible_config_file(opts),

--- a/lib/mix/tasks/ansible.deploy.ex
+++ b/lib/mix/tasks/ansible.deploy.ex
@@ -37,7 +37,7 @@ defmodule Mix.Tasks.Ansible.Deploy do
   """
 
   def run(args) do
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          :ok <- DeployExHelpers.ensure_ansible_installed() do
       opts = parse_args(args)
 

--- a/lib/mix/tasks/ansible.ping.ex
+++ b/lib/mix/tasks/ansible.ping.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Ansible.Ping do
   def run(args) do
     ansible_args = DeployEx.Ansible.parse_args(args)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       DeployExHelpers.check_file_exists!("./deploys/ansible/aws_ec2.yaml")
 
       DeployEx.Utils.run_command(

--- a/lib/mix/tasks/ansible.rollback.ex
+++ b/lib/mix/tasks/ansible.rollback.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Ansible.Rollback do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, node_name_args} = parse_args(args)
 
       opts = opts

--- a/lib/mix/tasks/ansible.setup.ex
+++ b/lib/mix/tasks/ansible.setup.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Ansible.Setup do
   """
 
   def run(args) do
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          :ok <- DeployExHelpers.ensure_ansible_installed() do
       opts = args
         |> parse_args

--- a/lib/mix/tasks/deploy_ex.autoscale.refresh.ex
+++ b/lib/mix/tasks/deploy_ex.autoscale.refresh.ex
@@ -78,7 +78,7 @@ defmodule Mix.Tasks.DeployEx.Autoscale.Refresh do
     min_healthy = Keyword.get(opts, :min_healthy_percentage, availability_defaults.min_healthy_percentage)
     max_healthy = Keyword.get(opts, :max_healthy_percentage, availability_defaults.max_healthy_percentage)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       Mix.shell().info([:blue, "Starting instance refresh for #{app_name}..."])
 
       preferences = %{

--- a/lib/mix/tasks/deploy_ex.autoscale.refresh_status.ex
+++ b/lib/mix/tasks/deploy_ex.autoscale.refresh_status.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.DeployEx.Autoscale.RefreshStatus do
     environment = Keyword.get(opts, :environment, Mix.env() |> to_string())
     show_all = Keyword.get(opts, :all, false)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       Mix.shell().info([:blue, "Fetching instance refresh status for #{app_name}..."])
 
       case AwsAutoscaling.find_asg_by_prefix(app_name, environment) do

--- a/lib/mix/tasks/deploy_ex.autoscale.scale.ex
+++ b/lib/mix/tasks/deploy_ex.autoscale.scale.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.DeployEx.Autoscale.Scale do
 
     environment = Keyword.get(opts, :environment, Mix.env() |> to_string())
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       Mix.shell().info([:blue, "Scaling #{app_name} to #{desired_capacity} instances..."])
 
       case AwsAutoscaling.find_asg_by_prefix(app_name, environment) do

--- a/lib/mix/tasks/deploy_ex.autoscale.status.ex
+++ b/lib/mix/tasks/deploy_ex.autoscale.status.ex
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.DeployEx.Autoscale.Status do
 
     environment = Keyword.get(opts, :environment, Mix.env() |> to_string())
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       Mix.shell().info([:blue, "Fetching autoscaling status for #{app_name}..."])
 
       case AwsAutoscaling.find_asg_by_prefix(app_name, environment) do

--- a/lib/mix/tasks/deploy_ex.download_file.ex
+++ b/lib/mix/tasks/deploy_ex.download_file.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.DeployEx.DownloadFile do
     {opts, node_name_args} = parse_args(args)
     opts = Keyword.put_new(opts, :directory, @terraform_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, [app_name, remote_path, local_path]} <- parse_node_name_args(node_name_args),
          {:ok, app_name} <- DeployExHelpers.find_project_name([app_name]),
          _ = Mix.shell().info([:yellow, "Downloading #{remote_path} from #{app_name}"]),

--- a/lib/mix/tasks/deploy_ex.full_drop.ex
+++ b/lib/mix/tasks/deploy_ex.full_drop.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.DeployEx.FullDrop do
   """
 
   def run(args) do
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       DeployExHelpers.check_file_exists!("./deploys/terraform")
 
       with :ok <- Mix.Tasks.Terraform.Drop.run(args) do

--- a/lib/mix/tasks/deploy_ex.full_setup.ex
+++ b/lib/mix/tasks/deploy_ex.full_setup.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.DeployEx.FullSetup do
   @time_between_pre_post :timer.seconds(10)
 
   def run(args) do
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       result = run_commands(@pre_setup_commands, args)
 
       if is_nil(result) do

--- a/lib/mix/tasks/deploy_ex.grafana.install_dashboard.ex
+++ b/lib/mix/tasks/deploy_ex.grafana.install_dashboard.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.DeployEx.Grafana.InstallDashboard do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, _extra_args} = parse_args(args)
 
       with {:ok, dashboard_json} <- load_dashboard(opts),

--- a/lib/mix/tasks/deploy_ex.install_github_action.ex
+++ b/lib/mix/tasks/deploy_ex.install_github_action.ex
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.DeployEx.InstallGithubAction do
       |> parse_args
       |> Keyword.put_new(:pem_directory, @terraform_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, releases} <- DeployExHelpers.fetch_mix_releases(),
          {:ok, pem_file_path} <- DeployEx.Terraform.find_pem_file(opts[:pem_directory], opts[:pem]) do
       @github_action_path |> Path.dirname |> File.mkdir_p!

--- a/lib/mix/tasks/deploy_ex.install_github_action.ex
+++ b/lib/mix/tasks/deploy_ex.install_github_action.ex
@@ -4,18 +4,7 @@ defmodule Mix.Tasks.DeployEx.InstallGithubAction do
   @terraform_default_path DeployEx.Config.terraform_folder_path()
 
   @github_action_path "./.github/workflows/deploy-ex-release.yml"
-  @github_action_template_path DeployExHelpers.priv_file("github-action.yml.eex")
-
   @github_action_setup_nodes_path "./.github/workflows/setup-new-nodes.yml"
-  @github_action_setup_nodes_template_path DeployExHelpers.priv_file("github-action-setup-nodes.yml.eex")
-
-  @github_action_scripts_paths [{
-    DeployExHelpers.priv_file("github-action-maybe-commit-terraform-changes.sh"),
-    "./.github/github-action-maybe-commit-terraform-changes.sh"
-  }, {
-    DeployExHelpers.priv_file("github-action-secrets-to-env.sh"),
-    "./.github/github-action-secrets-to-env.sh"
-  }]
   @shortdoc "Installs GitHub Actions for automated infrastructure and deployment management"
   @moduledoc """
   Installs GitHub Action workflows that automate infrastructure management and application deployment.
@@ -54,6 +43,15 @@ defmodule Mix.Tasks.DeployEx.InstallGithubAction do
       |> parse_args
       |> Keyword.put_new(:pem_directory, @terraform_default_path)
 
+    github_action_template_path = DeployExHelpers.priv_folder("github-action.yml.eex")
+    github_action_setup_nodes_template_path = DeployExHelpers.priv_folder("github-action-setup-nodes.yml.eex")
+    github_action_scripts_paths = [
+      {DeployExHelpers.priv_folder("github-action-maybe-commit-terraform-changes.sh"),
+       "./.github/github-action-maybe-commit-terraform-changes.sh"},
+      {DeployExHelpers.priv_folder("github-action-secrets-to-env.sh"),
+       "./.github/github-action-secrets-to-env.sh"}
+    ]
+
     with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, releases} <- DeployExHelpers.fetch_mix_releases(),
          {:ok, pem_file_path} <- DeployEx.Terraform.find_pem_file(opts[:pem_directory], opts[:pem]) do
@@ -62,7 +60,7 @@ defmodule Mix.Tasks.DeployEx.InstallGithubAction do
       app_names = releases |> Keyword.keys |> Enum.map(&to_string/1)
 
       DeployExHelpers.write_template(
-        @github_action_template_path,
+        github_action_template_path,
         @github_action_path,
         %{
           app_names: app_names,
@@ -72,7 +70,7 @@ defmodule Mix.Tasks.DeployEx.InstallGithubAction do
       )
 
       DeployExHelpers.write_template(
-        @github_action_setup_nodes_template_path,
+        github_action_setup_nodes_template_path,
         @github_action_setup_nodes_path,
         %{
           app_names: app_names
@@ -80,7 +78,7 @@ defmodule Mix.Tasks.DeployEx.InstallGithubAction do
         opts
       )
 
-      Enum.each(@github_action_scripts_paths, fn {input_path, output_path} ->
+      Enum.each(github_action_scripts_paths, fn {input_path, output_path} ->
         DeployExHelpers.check_file_exists!(input_path)
 
         DeployExHelpers.write_file(

--- a/lib/mix/tasks/deploy_ex.install_migration_script.ex
+++ b/lib/mix/tasks/deploy_ex.install_migration_script.ex
@@ -2,7 +2,6 @@ defmodule Mix.Tasks.DeployEx.InstallMigrationScript do
   use Mix.Task
 
   @scripts_default_path Path.join(DeployEx.Config.deploy_folder(), "scripts")
-  @migration_script_template_path DeployExHelpers.priv_file("migration_script.sh.eex")
 
   @shortdoc "Installs migration scripts for running Ecto migrations in releases"
   @moduledoc """
@@ -36,6 +35,8 @@ defmodule Mix.Tasks.DeployEx.InstallMigrationScript do
       |> parse_args()
       |> Keyword.put_new(:directory, @scripts_default_path)
 
+    migration_script_template_path = DeployExHelpers.priv_folder("migration_script.sh.eex")
+
     with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, releases} <- DeployExHelpers.release_apps_by_release_name() do
       File.mkdir_p!(opts[:directory])
@@ -45,7 +46,7 @@ defmodule Mix.Tasks.DeployEx.InstallMigrationScript do
         output_path = Path.join(opts[:directory], "migrate-#{app_name}.sh")
 
         DeployExHelpers.write_template(
-          @migration_script_template_path,
+          migration_script_template_path,
           output_path,
           %{
             app_name: app_name,

--- a/lib/mix/tasks/deploy_ex.install_migration_script.ex
+++ b/lib/mix/tasks/deploy_ex.install_migration_script.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.DeployEx.InstallMigrationScript do
       |> parse_args()
       |> Keyword.put_new(:directory, @scripts_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, releases} <- DeployExHelpers.release_apps_by_release_name() do
       File.mkdir_p!(opts[:directory])
 

--- a/lib/mix/tasks/deploy_ex.instance.health.ex
+++ b/lib/mix/tasks/deploy_ex.instance.health.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.DeployEx.Instance.Health do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
       opts = Map.new(opts)
 

--- a/lib/mix/tasks/deploy_ex.instance.status.ex
+++ b/lib/mix/tasks/deploy_ex.instance.status.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.DeployEx.Instance.Status do
 
     environment = Keyword.get(opts, :environment, Mix.env() |> to_string())
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       Mix.shell().info([:blue, "Fetching instance status for #{app_name}..."])
 
       display_autoscaling_status(app_name, environment)

--- a/lib/mix/tasks/deploy_ex.list_app_release_history.ex
+++ b/lib/mix/tasks/deploy_ex.list_app_release_history.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.DeployEx.ListAppReleaseHistory do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
 
       opts = opts

--- a/lib/mix/tasks/deploy_ex.list_available_releases.ex
+++ b/lib/mix/tasks/deploy_ex.list_available_releases.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.DeployEx.ListAvailableReleases do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, _extra_args} = parse_args(args)
       fetch_opts = [
         aws_release_bucket: DeployEx.Config.aws_release_bucket(),

--- a/lib/mix/tasks/deploy_ex.load_balancer.health.ex
+++ b/lib/mix/tasks/deploy_ex.load_balancer.health.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.DeployEx.LoadBalancer.Health do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
 
       DeployEx.TUI.setup_no_tui(opts)

--- a/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, _extra_args} = parse_args(args)
 
       with {:ok, _runner} <- maybe_reuse_or_create(opts) do

--- a/lib/mix/tasks/deploy_ex.load_test.destroy_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.destroy_instance.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.DestroyInstance do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, _extra_args} = parse_args(args)
 
       runners = find_runners_to_destroy(opts)

--- a/lib/mix/tasks/deploy_ex.load_test.exec.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.exec.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
 
       app_name = case extra_args do

--- a/lib/mix/tasks/deploy_ex.load_test.list.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.list.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.List do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       opts = parse_args(args)
 
       case list_runners(opts) do

--- a/lib/mix/tasks/deploy_ex.load_test.upload.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.upload.ex
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Upload do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
 
       app_name = case extra_args do

--- a/lib/mix/tasks/deploy_ex.qa.attach_lb.ex
+++ b/lib/mix/tasks/deploy_ex.qa.attach_lb.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.DeployEx.Qa.AttachLb do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
 
       app_name = case extra_args do

--- a/lib/mix/tasks/deploy_ex.qa.cleanup.ex
+++ b/lib/mix/tasks/deploy_ex.qa.cleanup.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.DeployEx.Qa.Cleanup do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       opts = parse_args(args)
 
       with {:ok, s3_orphans} <- find_s3_orphans(opts),

--- a/lib/mix/tasks/deploy_ex.qa.create.ex
+++ b/lib/mix/tasks/deploy_ex.qa.create.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
 
       DeployEx.TUI.setup_no_tui(opts)

--- a/lib/mix/tasks/deploy_ex.qa.deploy.ex
+++ b/lib/mix/tasks/deploy_ex.qa.deploy.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.DeployEx.Qa.Deploy do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          :ok <- DeployExHelpers.ensure_ansible_installed() do
       {opts, extra_args} = parse_args(args)
 

--- a/lib/mix/tasks/deploy_ex.qa.destroy.ex
+++ b/lib/mix/tasks/deploy_ex.qa.destroy.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.DeployEx.Qa.Destroy do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
 
       qa_nodes = find_qa_nodes_to_destroy(extra_args, opts)

--- a/lib/mix/tasks/deploy_ex.qa.detach_lb.ex
+++ b/lib/mix/tasks/deploy_ex.qa.detach_lb.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.DeployEx.Qa.DetachLb do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
 
       app_name = case extra_args do

--- a/lib/mix/tasks/deploy_ex.qa.list.ex
+++ b/lib/mix/tasks/deploy_ex.qa.list.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.DeployEx.Qa.List do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       opts = parse_args(args)
 
       case list_qa_nodes(opts) do

--- a/lib/mix/tasks/deploy_ex.release.ex
+++ b/lib/mix/tasks/deploy_ex.release.ex
@@ -45,12 +45,14 @@ defmodule Mix.Tasks.DeployEx.Release do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:telemetry)
 
-    opts = args
+    opts =
+      args
       |> parse_args
       |> Keyword.put_new(:aws_release_bucket, @default_aws_release_bucket)
       |> Keyword.put_new(:aws_region, @default_aws_region)
 
-    opts = opts
+    opts =
+      opts
       |> Keyword.put(:only, Keyword.get_values(opts, :only))
       |> Keyword.put(:except, Keyword.get_values(opts, :except))
       |> Keyword.put(:qa_release, qa_release?())
@@ -59,10 +61,13 @@ defmodule Mix.Tasks.DeployEx.Release do
          {:ok, releases} <- DeployExHelpers.fetch_mix_releases(),
          {:ok, remote_releases} <- ReleaseUploader.fetch_all_remote_releases(opts),
          {:ok, git_sha} <- ReleaseUploader.get_git_sha(),
-         :ok <- build_state_and_upload_unchanged_releases(
-           releases, remote_releases,
-           git_sha, opts
-         ) do
+         :ok <-
+           build_state_and_upload_unchanged_releases(
+             releases,
+             remote_releases,
+             git_sha,
+             opts
+           ) do
       :ok
     else
       {:error, e} -> Mix.raise(to_string(e))
@@ -71,28 +76,29 @@ defmodule Mix.Tasks.DeployEx.Release do
 
   defp build_state_and_upload_unchanged_releases(releases, remote_releases, git_sha, opts) do
     releases
-      |> Keyword.keys
-      |> Enum.map(&to_string/1)
-      |> DeployExHelpers.filter_only_or_except(opts[:only], opts[:except])
-      |> ReleaseUploader.build_state(remote_releases, git_sha, opts)
-      |> Enum.reject(&Mix.Tasks.DeployEx.Upload.already_uploaded?/1)
-      |> split_releases_and_run_release_commands(opts)
+    |> Keyword.keys()
+    |> Enum.map(&to_string/1)
+    |> DeployExHelpers.filter_only_or_except(opts[:only], opts[:except])
+    |> ReleaseUploader.build_state(remote_releases, git_sha, opts)
+    |> Enum.reject(&Mix.Tasks.DeployEx.Upload.already_uploaded?/1)
+    |> split_releases_and_run_release_commands(opts)
   end
 
   defp parse_args(args) do
-    {opts, _} = OptionParser.parse!(args,
-      aliases: [f: :force, q: :quit, r: :recompile],
-      switches: [
-        force: :boolean,
-        quiet: :boolean,
-        recompile: :boolean,
-        aws_region: :string,
-        aws_release_bucket: :string,
-        only: :keep,
-        except: :keep,
-        all: :boolean
-      ]
-    )
+    {opts, _} =
+      OptionParser.parse!(args,
+        aliases: [f: :force, q: :quit, r: :recompile],
+        switches: [
+          force: :boolean,
+          quiet: :boolean,
+          recompile: :boolean,
+          aws_region: :string,
+          aws_release_bucket: :string,
+          only: :keep,
+          except: :keep,
+          all: :boolean
+        ]
+      )
 
     opts
   end
@@ -116,26 +122,33 @@ defmodule Mix.Tasks.DeployEx.Release do
 
   defp split_releases_and_run_release_commands(release_states, opts) do
     with {
-      :ok,
-      app_type_release_state_tuples
-    } <- filter_changed_releases_and_mark_release_type(release_states, opts) do
-      {has_previous_upload_release_cands, no_prio_upload_release_cands} = Enum.split_with(
-        app_type_release_state_tuples,
-        fn {_app_type, %ReleaseUploader.State{last_sha: last_sha}} -> last_sha end
-      )
+           :ok,
+           app_type_release_state_tuples
+         } <- filter_changed_releases_and_mark_release_type(release_states, opts) do
+      {has_previous_upload_release_cands, no_prio_upload_release_cands} =
+        Enum.split_with(
+          app_type_release_state_tuples,
+          fn {_app_type, %ReleaseUploader.State{last_sha: last_sha}} -> last_sha end
+        )
 
-      if Enum.any?(has_previous_upload_release_cands) or Enum.any?(no_prio_upload_release_cands)  do
+      if Enum.any?(has_previous_upload_release_cands) or Enum.any?(no_prio_upload_release_cands) do
         with {:ok, initial_releases} <- run_initial_release(no_prio_upload_release_cands, opts),
-             {:ok, update_releases} <- run_update_releases(has_previous_upload_release_cands, opts) do
+             {:ok, update_releases} <-
+               run_update_releases(has_previous_upload_release_cands, opts) do
           Mix.shell().info([
-            :green, "Successfuly built ",
-            :reset, Enum.map_join(initial_releases ++ update_releases, ", ", &(&1.app_name))
+            :green,
+            "Successfuly built ",
+            :reset,
+            Enum.map_join(initial_releases ++ update_releases, ", ", & &1.app_name)
           ])
 
           :ok
         else
           {:error, [h | tail]} ->
-            Enum.each(tail, &Mix.shell().error("Error with releasing #{inspect(&1, pretty: true)}"))
+            Enum.each(
+              tail,
+              &Mix.shell().error("Error with releasing #{inspect(&1, pretty: true)}")
+            )
 
             Mix.raise(inspect(h, pretty: true))
         end
@@ -144,8 +157,10 @@ defmodule Mix.Tasks.DeployEx.Release do
           Mix.shell().info([:yellow, "No new changes found for releases"])
         else
           Mix.shell().info([
-            :yellow, "No new changes found for ",
-            :reset, Enum.map_join(release_states, ", ", &(&1.app_name))
+            :yellow,
+            "No new changes found for ",
+            :reset,
+            Enum.map_join(release_states, ", ", & &1.app_name)
           ])
         end
       end
@@ -155,23 +170,25 @@ defmodule Mix.Tasks.DeployEx.Release do
   defp filter_changed_releases_and_mark_release_type(release_states, opts) do
     with {:ok, app_dep_tree} <- ReleaseUploader.app_dep_tree() do
       if opts[:all] do
-        {:ok, Enum.map(
-          release_states,
-          &create_app_type_release_state_tuple(&1, app_dep_tree)
-        )}
+        {:ok,
+         Enum.map(
+           release_states,
+           &create_app_type_release_state_tuple(&1, app_dep_tree)
+         )}
       else
         with {:ok, release_states} <- ReleaseUploader.filter_changed_releases(release_states) do
-          {:ok, Enum.map(
-            release_states,
-            &create_app_type_release_state_tuple(&1, app_dep_tree)
-          )}
+          {:ok,
+           Enum.map(
+             release_states,
+             &create_app_type_release_state_tuple(&1, app_dep_tree)
+           )}
         end
       end
     end
   end
 
   defp create_app_type_release_state_tuple(%ReleaseUploader.State{} = release_state, app_dep_tree) do
-    deps_in_release_app = Enum.flat_map(release_state.release_apps, &(app_dep_tree[&1]))
+    deps_in_release_app = Enum.flat_map(release_state.release_apps, &app_dep_tree[&1])
 
     if "phoenix" in deps_in_release_app do
       {:phoenix, release_state}
@@ -182,50 +199,66 @@ defmodule Mix.Tasks.DeployEx.Release do
 
   defp run_initial_release(release_candidates, opts) do
     release_candidates
-      |> Enum.map(fn {app_type, %ReleaseUploader.State{} = candidate} ->
-        Mix.shell().info([
-          :green, "* running initial release for ",
-          :reset, candidate.local_file
-        ])
+    |> Enum.map(fn {app_type, %ReleaseUploader.State{} = candidate} ->
+      Mix.shell().info([
+        :green,
+        "* running initial release for ",
+        :reset,
+        candidate.local_file
+      ])
 
-        run_app_type_pre_release(app_type, candidate)
-        run_mix_release(candidate, opts)
-      end)
-      |> DeployEx.Utils.reduce_status_tuples
+      run_app_type_pre_release(app_type, candidate)
+      run_mix_release(candidate, opts)
+    end)
+    |> DeployEx.Utils.reduce_status_tuples()
   end
 
   defp run_update_releases(release_candidates, opts) do
     release_candidates
-      |> Enum.map(fn {app_type, %ReleaseUploader.State{} = candidate} ->
-        Mix.shell().info([
-          :green, "* running release to update ",
-          :reset, candidate.local_file
-        ])
+    |> Enum.map(fn {app_type, %ReleaseUploader.State{} = candidate} ->
+      Mix.shell().info([
+        :green,
+        "* running release to update ",
+        :reset,
+        candidate.local_file
+      ])
 
-        run_app_type_pre_release(app_type, candidate)
-        run_mix_release(candidate, opts)
-      end)
-      |> DeployEx.Utils.reduce_status_tuples
+      run_app_type_pre_release(app_type, candidate)
+      run_mix_release(candidate, opts)
+    end)
+    |> DeployEx.Utils.reduce_status_tuples()
   end
 
   defp run_app_type_pre_release(:phoenix, candidate) do
-    app_path = Mix.Project.apps_paths()[String.to_atom(candidate.app_name)]
+    app_path = DeployEx.ProjectContext.app_path(candidate.app_name)
     package_json_path = Path.join(app_path, "assets/package.json")
 
     has_package_lock? = File.exists?(package_json_path)
 
     if has_package_lock? do
       assets_path = Path.dirname(package_json_path)
+
       Mix.shell().info([
-        :green, "* running ",
-        :reset, "npm install ", :green, "for ",
-        :reset, candidate.app_name, :green, " in ",
-        :reset, assets_path
+        :green,
+        "* running ",
+        :reset,
+        "npm install ",
+        :green,
+        "for ",
+        :reset,
+        candidate.app_name,
+        :green,
+        " in ",
+        :reset,
+        assets_path
       ])
 
       case System.shell("npm i", cd: assets_path, into: IO.stream()) do
-        {_, 0} ->  :ok
-        {output, code} -> Mix.raise("Error running npm i #{code}\n#{inspect(output, pretty: true)}")
+        {_, 0} ->
+          :ok
+
+        {output, code} ->
+          Mix.raise("Error running npm i #{code}\n#{inspect(output, pretty: true)}")
       end
     end
 
@@ -240,42 +273,83 @@ defmodule Mix.Tasks.DeployEx.Release do
 
   defp run_phoenix_asset_pipeline(app_name) do
     app_name_atom = String.to_atom(app_name)
-    app_path = Mix.Project.apps_paths()[app_name_atom]
+    app_path = DeployEx.ProjectContext.app_path(app_name)
 
-    with {:ok, js_files} <- app_path |> Path.join("./assets/js") |> File.ls do
+    with {:ok, js_files} <- app_path |> Path.join("./assets/js") |> File.ls() do
       if Enum.any?(js_files) do
         Mix.shell().info([
-          :green, "* running ", :reset, "esbuild",
-          :green, " for ", :reset, app_name
+          :green,
+          "* running ",
+          :reset,
+          "esbuild",
+          :green,
+          " for ",
+          :reset,
+          app_name
         ])
 
-        Mix.Task.run("do", ["--app", app_name, "esbuild", build_config_name(:esbuild, app_name_atom), "--minify"])
+        Mix.Task.run("do", [
+          "--app",
+          app_name,
+          "esbuild",
+          build_config_name(:esbuild, app_name_atom),
+          "--minify"
+        ])
       end
     end
 
-    with {:ok, css_files} <- app_path |> Path.join("./assets/css") |> File.ls do
-      if css_files |> Enum.filter(&(&1 =~ ~r/\.s(a|c)ss$/)) |> Enum.any? do
+    with {:ok, css_files} <- app_path |> Path.join("./assets/css") |> File.ls() do
+      if css_files |> Enum.filter(&(&1 =~ ~r/\.s(a|c)ss$/)) |> Enum.any?() do
         Mix.shell().info([
-          :green, "* running ", :reset, "sass",
-          :green, " for ", :reset, app_name
+          :green,
+          "* running ",
+          :reset,
+          "sass",
+          :green,
+          " for ",
+          :reset,
+          app_name
         ])
 
-        Mix.Task.run("do", ["--app", app_name, "sass", build_config_name(:dart_sass, app_name_atom)])
+        Mix.Task.run("do", [
+          "--app",
+          app_name,
+          "sass",
+          build_config_name(:dart_sass, app_name_atom)
+        ])
       end
     end
 
-    if app_path |> Path.join("./assets/tailwind.config.js") |> File.exists? do
+    if app_path |> Path.join("./assets/tailwind.config.js") |> File.exists?() do
       Mix.shell().info([
-        :green, "* running ", :reset, "tailwind",
-        :green, " for ", :reset, app_name
+        :green,
+        "* running ",
+        :reset,
+        "tailwind",
+        :green,
+        " for ",
+        :reset,
+        app_name
       ])
 
-      Mix.Task.run("do", ["--app", app_name, "tailwind", build_config_name(:tailwind, app_name_atom), "--minify"])
+      Mix.Task.run("do", [
+        "--app",
+        app_name,
+        "tailwind",
+        build_config_name(:tailwind, app_name_atom),
+        "--minify"
+      ])
     end
 
     Mix.shell().info([
-      :green, "* running ", :reset, "phoenix digest",
-      :green, " for ", :reset, app_name
+      :green,
+      "* running ",
+      :reset,
+      "phoenix digest",
+      :green,
+      " for ",
+      :reset,
+      app_name
     ])
 
     Mix.Task.run("do", ["--app", app_name, "phx.digest"])
@@ -290,18 +364,25 @@ defmodule Mix.Tasks.DeployEx.Release do
   end
 
   defp run_mix_release(%ReleaseUploader.State{app_name: app_name} = candidate, opts) do
-    args = Enum.reduce(opts, [], fn
-      {:force, true}, acc -> ["--overwrite" | acc]
-      {:recompile, true}, acc -> ["--force" | acc]
-      {:quiet, true}, acc -> ["--quiet" | acc]
-      _, acc -> acc
-    end)
+    args =
+      Enum.reduce(opts, [], fn
+        {:force, true}, acc -> ["--overwrite" | acc]
+        {:recompile, true}, acc -> ["--force" | acc]
+        {:quiet, true}, acc -> ["--quiet" | acc]
+        _, acc -> acc
+      end)
 
     Mix.Task.clear()
+
     case Mix.Task.run("release", [app_name | args]) do
-      :ok -> {:ok, candidate}
-      :noop -> {:ok, candidate}
-      {:error, reason} -> {:ok, ErrorMessage.failed_dependency("mix release failed", %{reason: reason})}
+      :ok ->
+        {:ok, candidate}
+
+      :noop ->
+        {:ok, candidate}
+
+      {:error, reason} ->
+        {:ok, ErrorMessage.failed_dependency("mix release failed", %{reason: reason})}
     end
   end
 end

--- a/lib/mix/tasks/deploy_ex.release.ex
+++ b/lib/mix/tasks/deploy_ex.release.ex
@@ -45,14 +45,12 @@ defmodule Mix.Tasks.DeployEx.Release do
     Application.ensure_all_started(:hackney)
     Application.ensure_all_started(:telemetry)
 
-    opts =
-      args
+    opts = args
       |> parse_args
       |> Keyword.put_new(:aws_release_bucket, @default_aws_release_bucket)
       |> Keyword.put_new(:aws_region, @default_aws_region)
 
-    opts =
-      opts
+    opts = opts
       |> Keyword.put(:only, Keyword.get_values(opts, :only))
       |> Keyword.put(:except, Keyword.get_values(opts, :except))
       |> Keyword.put(:qa_release, qa_release?())
@@ -61,13 +59,10 @@ defmodule Mix.Tasks.DeployEx.Release do
          {:ok, releases} <- DeployExHelpers.fetch_mix_releases(),
          {:ok, remote_releases} <- ReleaseUploader.fetch_all_remote_releases(opts),
          {:ok, git_sha} <- ReleaseUploader.get_git_sha(),
-         :ok <-
-           build_state_and_upload_unchanged_releases(
-             releases,
-             remote_releases,
-             git_sha,
-             opts
-           ) do
+         :ok <- build_state_and_upload_unchanged_releases(
+           releases, remote_releases,
+           git_sha, opts
+         ) do
       :ok
     else
       {:error, e} -> Mix.raise(to_string(e))
@@ -76,29 +71,28 @@ defmodule Mix.Tasks.DeployEx.Release do
 
   defp build_state_and_upload_unchanged_releases(releases, remote_releases, git_sha, opts) do
     releases
-    |> Keyword.keys()
-    |> Enum.map(&to_string/1)
-    |> DeployExHelpers.filter_only_or_except(opts[:only], opts[:except])
-    |> ReleaseUploader.build_state(remote_releases, git_sha, opts)
-    |> Enum.reject(&Mix.Tasks.DeployEx.Upload.already_uploaded?/1)
-    |> split_releases_and_run_release_commands(opts)
+      |> Keyword.keys
+      |> Enum.map(&to_string/1)
+      |> DeployExHelpers.filter_only_or_except(opts[:only], opts[:except])
+      |> ReleaseUploader.build_state(remote_releases, git_sha, opts)
+      |> Enum.reject(&Mix.Tasks.DeployEx.Upload.already_uploaded?/1)
+      |> split_releases_and_run_release_commands(opts)
   end
 
   defp parse_args(args) do
-    {opts, _} =
-      OptionParser.parse!(args,
-        aliases: [f: :force, q: :quit, r: :recompile],
-        switches: [
-          force: :boolean,
-          quiet: :boolean,
-          recompile: :boolean,
-          aws_region: :string,
-          aws_release_bucket: :string,
-          only: :keep,
-          except: :keep,
-          all: :boolean
-        ]
-      )
+    {opts, _} = OptionParser.parse!(args,
+      aliases: [f: :force, q: :quit, r: :recompile],
+      switches: [
+        force: :boolean,
+        quiet: :boolean,
+        recompile: :boolean,
+        aws_region: :string,
+        aws_release_bucket: :string,
+        only: :keep,
+        except: :keep,
+        all: :boolean
+      ]
+    )
 
     opts
   end
@@ -122,33 +116,26 @@ defmodule Mix.Tasks.DeployEx.Release do
 
   defp split_releases_and_run_release_commands(release_states, opts) do
     with {
-           :ok,
-           app_type_release_state_tuples
-         } <- filter_changed_releases_and_mark_release_type(release_states, opts) do
-      {has_previous_upload_release_cands, no_prio_upload_release_cands} =
-        Enum.split_with(
-          app_type_release_state_tuples,
-          fn {_app_type, %ReleaseUploader.State{last_sha: last_sha}} -> last_sha end
-        )
+      :ok,
+      app_type_release_state_tuples
+    } <- filter_changed_releases_and_mark_release_type(release_states, opts) do
+      {has_previous_upload_release_cands, no_prio_upload_release_cands} = Enum.split_with(
+        app_type_release_state_tuples,
+        fn {_app_type, %ReleaseUploader.State{last_sha: last_sha}} -> last_sha end
+      )
 
-      if Enum.any?(has_previous_upload_release_cands) or Enum.any?(no_prio_upload_release_cands) do
+      if Enum.any?(has_previous_upload_release_cands) or Enum.any?(no_prio_upload_release_cands)  do
         with {:ok, initial_releases} <- run_initial_release(no_prio_upload_release_cands, opts),
-             {:ok, update_releases} <-
-               run_update_releases(has_previous_upload_release_cands, opts) do
+             {:ok, update_releases} <- run_update_releases(has_previous_upload_release_cands, opts) do
           Mix.shell().info([
-            :green,
-            "Successfuly built ",
-            :reset,
-            Enum.map_join(initial_releases ++ update_releases, ", ", & &1.app_name)
+            :green, "Successfuly built ",
+            :reset, Enum.map_join(initial_releases ++ update_releases, ", ", &(&1.app_name))
           ])
 
           :ok
         else
           {:error, [h | tail]} ->
-            Enum.each(
-              tail,
-              &Mix.shell().error("Error with releasing #{inspect(&1, pretty: true)}")
-            )
+            Enum.each(tail, &Mix.shell().error("Error with releasing #{inspect(&1, pretty: true)}"))
 
             Mix.raise(inspect(h, pretty: true))
         end
@@ -157,10 +144,8 @@ defmodule Mix.Tasks.DeployEx.Release do
           Mix.shell().info([:yellow, "No new changes found for releases"])
         else
           Mix.shell().info([
-            :yellow,
-            "No new changes found for ",
-            :reset,
-            Enum.map_join(release_states, ", ", & &1.app_name)
+            :yellow, "No new changes found for ",
+            :reset, Enum.map_join(release_states, ", ", &(&1.app_name))
           ])
         end
       end
@@ -170,25 +155,23 @@ defmodule Mix.Tasks.DeployEx.Release do
   defp filter_changed_releases_and_mark_release_type(release_states, opts) do
     with {:ok, app_dep_tree} <- ReleaseUploader.app_dep_tree() do
       if opts[:all] do
-        {:ok,
-         Enum.map(
-           release_states,
-           &create_app_type_release_state_tuple(&1, app_dep_tree)
-         )}
+        {:ok, Enum.map(
+          release_states,
+          &create_app_type_release_state_tuple(&1, app_dep_tree)
+        )}
       else
         with {:ok, release_states} <- ReleaseUploader.filter_changed_releases(release_states) do
-          {:ok,
-           Enum.map(
-             release_states,
-             &create_app_type_release_state_tuple(&1, app_dep_tree)
-           )}
+          {:ok, Enum.map(
+            release_states,
+            &create_app_type_release_state_tuple(&1, app_dep_tree)
+          )}
         end
       end
     end
   end
 
   defp create_app_type_release_state_tuple(%ReleaseUploader.State{} = release_state, app_dep_tree) do
-    deps_in_release_app = Enum.flat_map(release_state.release_apps, &app_dep_tree[&1])
+    deps_in_release_app = Enum.flat_map(release_state.release_apps, &(app_dep_tree[&1]))
 
     if "phoenix" in deps_in_release_app do
       {:phoenix, release_state}
@@ -199,34 +182,30 @@ defmodule Mix.Tasks.DeployEx.Release do
 
   defp run_initial_release(release_candidates, opts) do
     release_candidates
-    |> Enum.map(fn {app_type, %ReleaseUploader.State{} = candidate} ->
-      Mix.shell().info([
-        :green,
-        "* running initial release for ",
-        :reset,
-        candidate.local_file
-      ])
+      |> Enum.map(fn {app_type, %ReleaseUploader.State{} = candidate} ->
+        Mix.shell().info([
+          :green, "* running initial release for ",
+          :reset, candidate.local_file
+        ])
 
-      run_app_type_pre_release(app_type, candidate)
-      run_mix_release(candidate, opts)
-    end)
-    |> DeployEx.Utils.reduce_status_tuples()
+        run_app_type_pre_release(app_type, candidate)
+        run_mix_release(candidate, opts)
+      end)
+      |> DeployEx.Utils.reduce_status_tuples
   end
 
   defp run_update_releases(release_candidates, opts) do
     release_candidates
-    |> Enum.map(fn {app_type, %ReleaseUploader.State{} = candidate} ->
-      Mix.shell().info([
-        :green,
-        "* running release to update ",
-        :reset,
-        candidate.local_file
-      ])
+      |> Enum.map(fn {app_type, %ReleaseUploader.State{} = candidate} ->
+        Mix.shell().info([
+          :green, "* running release to update ",
+          :reset, candidate.local_file
+        ])
 
-      run_app_type_pre_release(app_type, candidate)
-      run_mix_release(candidate, opts)
-    end)
-    |> DeployEx.Utils.reduce_status_tuples()
+        run_app_type_pre_release(app_type, candidate)
+        run_mix_release(candidate, opts)
+      end)
+      |> DeployEx.Utils.reduce_status_tuples
   end
 
   defp run_app_type_pre_release(:phoenix, candidate) do
@@ -237,28 +216,16 @@ defmodule Mix.Tasks.DeployEx.Release do
 
     if has_package_lock? do
       assets_path = Path.dirname(package_json_path)
-
       Mix.shell().info([
-        :green,
-        "* running ",
-        :reset,
-        "npm install ",
-        :green,
-        "for ",
-        :reset,
-        candidate.app_name,
-        :green,
-        " in ",
-        :reset,
-        assets_path
+        :green, "* running ",
+        :reset, "npm install ", :green, "for ",
+        :reset, candidate.app_name, :green, " in ",
+        :reset, assets_path
       ])
 
       case System.shell("npm i", cd: assets_path, into: IO.stream()) do
-        {_, 0} ->
-          :ok
-
-        {output, code} ->
-          Mix.raise("Error running npm i #{code}\n#{inspect(output, pretty: true)}")
+        {_, 0} ->  :ok
+        {output, code} -> Mix.raise("Error running npm i #{code}\n#{inspect(output, pretty: true)}")
       end
     end
 
@@ -275,81 +242,40 @@ defmodule Mix.Tasks.DeployEx.Release do
     app_name_atom = String.to_atom(app_name)
     app_path = DeployEx.ProjectContext.app_path(app_name)
 
-    with {:ok, js_files} <- app_path |> Path.join("./assets/js") |> File.ls() do
+    with {:ok, js_files} <- app_path |> Path.join("./assets/js") |> File.ls do
       if Enum.any?(js_files) do
         Mix.shell().info([
-          :green,
-          "* running ",
-          :reset,
-          "esbuild",
-          :green,
-          " for ",
-          :reset,
-          app_name
+          :green, "* running ", :reset, "esbuild",
+          :green, " for ", :reset, app_name
         ])
 
-        Mix.Task.run("do", [
-          "--app",
-          app_name,
-          "esbuild",
-          build_config_name(:esbuild, app_name_atom),
-          "--minify"
-        ])
+        Mix.Task.run("do", ["--app", app_name, "esbuild", build_config_name(:esbuild, app_name_atom), "--minify"])
       end
     end
 
-    with {:ok, css_files} <- app_path |> Path.join("./assets/css") |> File.ls() do
-      if css_files |> Enum.filter(&(&1 =~ ~r/\.s(a|c)ss$/)) |> Enum.any?() do
+    with {:ok, css_files} <- app_path |> Path.join("./assets/css") |> File.ls do
+      if css_files |> Enum.filter(&(&1 =~ ~r/\.s(a|c)ss$/)) |> Enum.any? do
         Mix.shell().info([
-          :green,
-          "* running ",
-          :reset,
-          "sass",
-          :green,
-          " for ",
-          :reset,
-          app_name
+          :green, "* running ", :reset, "sass",
+          :green, " for ", :reset, app_name
         ])
 
-        Mix.Task.run("do", [
-          "--app",
-          app_name,
-          "sass",
-          build_config_name(:dart_sass, app_name_atom)
-        ])
+        Mix.Task.run("do", ["--app", app_name, "sass", build_config_name(:dart_sass, app_name_atom)])
       end
     end
 
-    if app_path |> Path.join("./assets/tailwind.config.js") |> File.exists?() do
+    if app_path |> Path.join("./assets/tailwind.config.js") |> File.exists? do
       Mix.shell().info([
-        :green,
-        "* running ",
-        :reset,
-        "tailwind",
-        :green,
-        " for ",
-        :reset,
-        app_name
+        :green, "* running ", :reset, "tailwind",
+        :green, " for ", :reset, app_name
       ])
 
-      Mix.Task.run("do", [
-        "--app",
-        app_name,
-        "tailwind",
-        build_config_name(:tailwind, app_name_atom),
-        "--minify"
-      ])
+      Mix.Task.run("do", ["--app", app_name, "tailwind", build_config_name(:tailwind, app_name_atom), "--minify"])
     end
 
     Mix.shell().info([
-      :green,
-      "* running ",
-      :reset,
-      "phoenix digest",
-      :green,
-      " for ",
-      :reset,
-      app_name
+      :green, "* running ", :reset, "phoenix digest",
+      :green, " for ", :reset, app_name
     ])
 
     Mix.Task.run("do", ["--app", app_name, "phx.digest"])
@@ -364,25 +290,18 @@ defmodule Mix.Tasks.DeployEx.Release do
   end
 
   defp run_mix_release(%ReleaseUploader.State{app_name: app_name} = candidate, opts) do
-    args =
-      Enum.reduce(opts, [], fn
-        {:force, true}, acc -> ["--overwrite" | acc]
-        {:recompile, true}, acc -> ["--force" | acc]
-        {:quiet, true}, acc -> ["--quiet" | acc]
-        _, acc -> acc
-      end)
+    args = Enum.reduce(opts, [], fn
+      {:force, true}, acc -> ["--overwrite" | acc]
+      {:recompile, true}, acc -> ["--force" | acc]
+      {:quiet, true}, acc -> ["--quiet" | acc]
+      _, acc -> acc
+    end)
 
     Mix.Task.clear()
-
     case Mix.Task.run("release", [app_name | args]) do
-      :ok ->
-        {:ok, candidate}
-
-      :noop ->
-        {:ok, candidate}
-
-      {:error, reason} ->
-        {:ok, ErrorMessage.failed_dependency("mix release failed", %{reason: reason})}
+      :ok -> {:ok, candidate}
+      :noop -> {:ok, candidate}
+      {:error, reason} -> {:ok, ErrorMessage.failed_dependency("mix release failed", %{reason: reason})}
     end
   end
 end

--- a/lib/mix/tasks/deploy_ex.release.ex
+++ b/lib/mix/tasks/deploy_ex.release.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.DeployEx.Release do
       |> Keyword.put(:except, Keyword.get_values(opts, :except))
       |> Keyword.put(:qa_release, qa_release?())
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, releases} <- DeployExHelpers.fetch_mix_releases(),
          {:ok, remote_releases} <- ReleaseUploader.fetch_all_remote_releases(opts),
          {:ok, git_sha} <- ReleaseUploader.get_git_sha(),

--- a/lib/mix/tasks/deploy_ex.remake.ex
+++ b/lib/mix/tasks/deploy_ex.remake.ex
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.DeployEx.Remake do
 
     DeployEx.TUI.setup_no_tui(opts)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, node_name} <- check_for_node_name(node_name) do
       args_without_name = node_name_as_only_arg(node_name, args)
 

--- a/lib/mix/tasks/deploy_ex.select_node.ex
+++ b/lib/mix/tasks/deploy_ex.select_node.ex
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.DeployEx.SelectNode do
 
     {opts, app_params} = parse_args(args)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, instance_infos} <- fetch_instances(app_params, opts),
          {:ok, selected_instance} <- select_instance(instance_infos) do
       output_selected(selected_instance, opts)

--- a/lib/mix/tasks/deploy_ex.ssh.authorize.ex
+++ b/lib/mix/tasks/deploy_ex.ssh.authorize.ex
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.DeployEx.Ssh.Authorize do
 
     opts = parse_args(args)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, security_group_id} <- DeployEx.AwsSecurityGroup.find_security_group_id(region: opts[:region], security_group_id: opts[:security_group_id]),
          :ok <- add_or_remove_whitelist(opts, security_group_id) do
       :ok

--- a/lib/mix/tasks/deploy_ex.ssh.ex
+++ b/lib/mix/tasks/deploy_ex.ssh.ex
@@ -68,7 +68,7 @@ defmodule Mix.Tasks.DeployEx.Ssh do
 
     {machine_opts, opts} = Keyword.split(opts, [:resource_group])
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       if opts[:qa] do
         app_name = List.first(app_params)
         run_qa_mode(app_name, machine_opts, opts)

--- a/lib/mix/tasks/deploy_ex.upload.ex
+++ b/lib/mix/tasks/deploy_ex.upload.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.DeployEx.Upload do
       |> Keyword.put_new(:parallel, @max_upload_concurrency)
       |> then(&Keyword.put(&1, :qa_release, qa_release?(&1)))
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, local_releases} <- ReleaseUploader.fetch_all_local_releases(),
          {:ok, remote_releases} <- ReleaseUploader.fetch_all_remote_releases(opts),
          {:ok, git_sha} <- ReleaseUploader.get_git_sha() do

--- a/lib/mix/tasks/deploy_ex.view_current_release.ex
+++ b/lib/mix/tasks/deploy_ex.view_current_release.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.DeployEx.ViewCurrentRelease do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       {opts, extra_args} = parse_args(args)
 
       opts = opts

--- a/lib/mix/tasks/terraform.apply.ex
+++ b/lib/mix/tasks/terraform.apply.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Terraform.Apply do
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          :ok <- run_command(args, opts) do
       :ok
     else

--- a/lib/mix/tasks/terraform.build.ex
+++ b/lib/mix/tasks/terraform.build.ex
@@ -124,7 +124,7 @@ defmodule Mix.Tasks.Terraform.Build do
       File.mkdir_p!(directory)
 
       "terraform"
-        |> DeployExHelpers.priv_file()
+        |> DeployExHelpers.priv_folder()
         |> File.cp_r!(directory)
 
       directory
@@ -271,7 +271,7 @@ defmodule Mix.Tasks.Terraform.Build do
   end
 
   defp write_terraform_template_files(params, opts) do
-    terraform_path = DeployExHelpers.priv_file("terraform")
+    terraform_path = DeployExHelpers.priv_folder("terraform")
 
     terraform_path
       |> Path.join("*.eex")

--- a/lib/mix/tasks/terraform.build.ex
+++ b/lib/mix/tasks/terraform.build.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Terraform.Build do
       |> Keyword.put_new(:env, Mix.env())
 
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, releases} <- DeployExHelpers.fetch_mix_releases(),
          :ok <- ensure_terraform_directory_exists(opts[:directory]) do
       random_bytes = 6 |> :crypto.strong_rand_bytes |> Base.encode32(padding: false)

--- a/lib/mix/tasks/terraform.create_ebs_snapshot.ex
+++ b/lib/mix/tasks/terraform.create_ebs_snapshot.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Terraform.CreateEbsSnapshot do
     region = opts[:aws_region] || Config.aws_region()
     {machine_opts, opts} = Keyword.split(opts, [:resource_group])
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, app_name} <- DeployExHelpers.find_project_name(app_params),
          {:ok, instance_ips} <- AwsMachine.find_instance_ips(DeployExHelpers.project_name(), app_name, machine_opts),
          {:ok, instances} <- find_instances_by_ips(region, instance_ips),

--- a/lib/mix/tasks/terraform.create_state_bucket.ex
+++ b/lib/mix/tasks/terraform.create_state_bucket.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Terraform.CreateStateBucket do
     # opts = Keyword.put_new(opts, :directory, @terraform_default_path)
     # {machine_opts, opts} = Keyword.split(opts, [:resource_group])
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, buckets} <- AwsBucket.list_buckets() do
       bucket = DeployEx.Config.aws_release_state_bucket()
       region = DeployEx.Config.aws_region()

--- a/lib/mix/tasks/terraform.create_state_lock_table.ex
+++ b/lib/mix/tasks/terraform.create_state_lock_table.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Terraform.CreateStateLockTable do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, tables} <- AwsDynamodb.list_tables() do
       table_name = DeployEx.Config.aws_release_state_lock_table()
       region = DeployEx.Config.aws_region()

--- a/lib/mix/tasks/terraform.delete_ebs_snapshot.ex
+++ b/lib/mix/tasks/terraform.delete_ebs_snapshot.ex
@@ -72,7 +72,7 @@ defmodule Mix.Tasks.Terraform.DeleteEbsSnapshot do
     region = opts[:aws_region] || Config.aws_region()
     {machine_opts, opts} = Keyword.split(opts, [:resource_group])
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, snapshots_to_delete} <- determine_snapshots_to_delete(region, app_params, machine_opts, opts),
          :ok <- confirm_deletion(snapshots_to_delete, opts),
          {:ok, deleted_snapshots} <- delete_snapshots(region, snapshots_to_delete) do

--- a/lib/mix/tasks/terraform.drop.ex
+++ b/lib/mix/tasks/terraform.drop.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Terraform.Drop do
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       cmd = "destroy #{DeployEx.Terraform.parse_args(args, :destroy)}"
       cmd = if opts[:auto_approve], do: "#{cmd} --auto-approve", else: cmd
 

--- a/lib/mix/tasks/terraform.drop_state_bucket.ex
+++ b/lib/mix/tasks/terraform.drop_state_bucket.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Terraform.DropStateBucket do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, buckets} <- AwsBucket.list_buckets() do
       bucket = DeployEx.Config.aws_release_state_bucket()
       region = DeployEx.Config.aws_region()

--- a/lib/mix/tasks/terraform.drop_state_lock_table.ex
+++ b/lib/mix/tasks/terraform.drop_state_lock_table.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Terraform.DropStateLockTable do
     Application.ensure_all_started(:telemetry)
     Application.ensure_all_started(:ex_aws)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, tables} <- AwsDynamodb.list_tables() do
       table_name = DeployEx.Config.aws_release_state_lock_table()
       region = DeployEx.Config.aws_region()

--- a/lib/mix/tasks/terraform.dump_database.ex
+++ b/lib/mix/tasks/terraform.dump_database.ex
@@ -61,7 +61,7 @@ defmodule Mix.Tasks.Terraform.DumpDatabase do
     state_opts = normalize_state_opts(state_opts)
 
     with :ok <- check_pg_dump_installed(),
-         :ok <- DeployExHelpers.check_in_umbrella(),
+         :ok <- DeployExHelpers.check_valid_project(),
          database_name when not is_nil(database_name) <- List.first(extra_args) || show_database_selection(),
          {:ok, db_info} <- AwsDatabase.get_database_info(database_name, opts[:identifier]),
          {:ok, password} <- AwsDatabase.get_database_password(db_info, opts[:directory], state_opts),

--- a/lib/mix/tasks/terraform.init.ex
+++ b/lib/mix/tasks/terraform.init.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Terraform.Init do
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          :ok <- run_terraform_init(args, opts) do
       :ok
     else

--- a/lib/mix/tasks/terraform.output.ex
+++ b/lib/mix/tasks/terraform.output.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Terraform.Output do
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       cmd = "output #{DeployEx.Terraform.parse_args(args, :output)}"
 
       cmd = if opts[:short], do: "#{cmd} --json", else: cmd

--- a/lib/mix/tasks/terraform.plan.ex
+++ b/lib/mix/tasks/terraform.plan.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Terraform.Plan do
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          :ok <- terraform_plan(args, opts) do
       :ok
     else

--- a/lib/mix/tasks/terraform.refresh.ex
+++ b/lib/mix/tasks/terraform.refresh.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Terraform.Refresh do
       |> parse_args
       |> Keyword.put_new(:directory, @terraform_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       DeployEx.Terraform.run_command_with_input(
         "refresh #{DeployEx.Terraform.parse_args(args, :refresh)}",
         opts[:directory]

--- a/lib/mix/tasks/terraform.replace.ex
+++ b/lib/mix/tasks/terraform.replace.ex
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.Terraform.Replace do
 
     opts = Keyword.put_new(opts, :directory, @terraform_default_path)
 
-    with :ok <- DeployExHelpers.check_in_umbrella() do
+    with :ok <- DeployExHelpers.check_valid_project() do
       if opts[:string] do
         terraform_apply_replace(opts[:string], DeployEx.Terraform.parse_args(args, :replace), opts)
       else

--- a/lib/mix/tasks/terraform.show_password.ex
+++ b/lib/mix/tasks/terraform.show_password.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Terraform.ShowPassword do
 
     maybe_start_aws_apps(state_opts[:backend])
 
-    with :ok <- DeployExHelpers.check_in_umbrella(),
+    with :ok <- DeployExHelpers.check_valid_project(),
          {:ok, state} <- DeployEx.TerraformState.read_state(directory, state_opts),
          database_name when not is_nil(database_name) <- List.first(extra_args) || show_database_selection(state),
          {:ok, password} <- DeployEx.TerraformState.get_resource_attribute_by_tag(

--- a/test/deploy_ex/project_context_test.exs
+++ b/test/deploy_ex/project_context_test.exs
@@ -1,0 +1,132 @@
+defmodule DeployEx.ProjectContextTest do
+  use ExUnit.Case, async: true
+
+  alias DeployEx.ProjectContext
+
+  defmodule FakeUmbrellaMixProject do
+    def umbrella?, do: true
+    def get, do: __MODULE__
+
+    def project,
+      do: [
+        apps_path: "test/support/fake_apps",
+        releases: [
+          app_a: [applications: [app_a: :permanent]],
+          app_b: [applications: [app_b: :permanent]]
+        ]
+      ]
+
+    def apps_paths,
+      do: %{app_a: "test/support/fake_apps/app_a", app_b: "test/support/fake_apps/app_b"}
+  end
+
+  defmodule FakeSingleAppMixProject do
+    def umbrella?, do: false
+    def get, do: __MODULE__
+    def project, do: [app: :my_app]
+    def apps_paths, do: %{}
+  end
+
+  defmodule FakeSingleAppWithReleasesMixProject do
+    def umbrella?, do: false
+    def get, do: __MODULE__
+
+    def project,
+      do: [
+        app: :my_app,
+        releases: [
+          web: [applications: [my_app: :permanent]],
+          worker: [applications: [my_app: :permanent]]
+        ]
+      ]
+
+    def apps_paths, do: %{}
+  end
+
+  defmodule FakeMalformedMixProject do
+    def umbrella?, do: false
+    def get, do: __MODULE__
+    def project, do: []
+    def apps_paths, do: %{}
+  end
+
+  describe "type/1" do
+    test "returns :umbrella for umbrella projects" do
+      assert ProjectContext.type(FakeUmbrellaMixProject) === :umbrella
+    end
+
+    test "returns :single_app for non-umbrella projects" do
+      assert ProjectContext.type(FakeSingleAppMixProject) === :single_app
+    end
+  end
+
+  describe "apps/1" do
+    test "returns app keys from apps_paths for umbrella" do
+      assert ProjectContext.apps(FakeUmbrellaMixProject) === ["app_a", "app_b"]
+    end
+
+    test "returns single app name for single-app project" do
+      assert ProjectContext.apps(FakeSingleAppMixProject) === ["my_app"]
+    end
+
+    test "returns single app name for single-app with explicit releases" do
+      assert ProjectContext.apps(FakeSingleAppWithReleasesMixProject) === ["my_app"]
+    end
+  end
+
+  describe "app_path/2" do
+    test "returns the mapped path for umbrella app" do
+      assert ProjectContext.app_path("app_a", FakeUmbrellaMixProject) ===
+               "test/support/fake_apps/app_a"
+    end
+
+    test "returns File.cwd! for single-app" do
+      assert ProjectContext.app_path("my_app", FakeSingleAppMixProject) === File.cwd!()
+    end
+  end
+
+  describe "releases/1" do
+    test "returns releases from mix.exs for umbrella" do
+      {:ok, releases} = ProjectContext.releases(FakeUmbrellaMixProject)
+      assert Keyword.has_key?(releases, :app_a)
+      assert Keyword.has_key?(releases, :app_b)
+    end
+
+    test "returns releases from mix.exs for single-app with explicit releases" do
+      {:ok, releases} = ProjectContext.releases(FakeSingleAppWithReleasesMixProject)
+      assert Keyword.has_key?(releases, :web)
+      assert Keyword.has_key?(releases, :worker)
+    end
+
+    test "synthesizes a release from :app key for single-app with no releases" do
+      {:ok, releases} = ProjectContext.releases(FakeSingleAppMixProject)
+      assert [{:my_app, opts}] = releases
+      assert opts[:applications] === [my_app: :permanent]
+    end
+
+    test "returns error for malformed project with no :app key" do
+      assert {:error, _} = ProjectContext.releases(FakeMalformedMixProject)
+    end
+  end
+
+  describe "redeploy_config/2" do
+    test "returns default RedeployConfig when no deploy_ex opts" do
+      {:ok, config} = ProjectContext.redeploy_config(:app_a, FakeUmbrellaMixProject)
+      assert %DeployEx.ReleaseUploader.RedeployConfig{} = config
+    end
+  end
+
+  describe "check_valid_project/1" do
+    test "returns :ok for umbrella project" do
+      assert :ok === ProjectContext.check_valid_project(FakeUmbrellaMixProject)
+    end
+
+    test "returns :ok for valid single-app project" do
+      assert :ok === ProjectContext.check_valid_project(FakeSingleAppMixProject)
+    end
+
+    test "returns error for malformed project" do
+      assert {:error, _} = ProjectContext.check_valid_project(FakeMalformedMixProject)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `DeployEx.ProjectContext` module that abstracts Mix project introspection for both umbrella and single-app projects
- `DeployExHelpers` delegates app/release discovery to `ProjectContext` instead of directly calling `Mix.Project.apps_paths()`
- Renames `check_in_umbrella` to `check_valid_project` across all 55+ task files — passes for both project types
- Fixes `UpdateValidator` change detection to handle single-app paths (`lib/`, `test/`, `priv/`) alongside umbrella paths (`apps/<name>/`)
- Single-app projects without explicit `releases:` in `mix.exs` get a synthesized release from the `:app` key

## How it works

For single-app projects (`mix new my_app`):
- `ProjectContext.apps()` returns `["my_app"]` (from `:app` key)
- `ProjectContext.app_path("my_app")` returns `File.cwd!()`
- `ProjectContext.releases()` synthesizes `[my_app: [applications: [my_app: :permanent]]]`
- All 66 Mix tasks work without changes

For umbrella projects: behavior is unchanged — `ProjectContext` delegates to existing `Mix.Project` APIs.

## Test plan

- [x] 15 new unit tests for `ProjectContext` (umbrella fake, single-app, single-app with releases, malformed project)
- [x] Existing 80 tests pass (8 pre-existing failures in `aws_infrastructure_test.exs`, unrelated)
- [x] Smoke tested in a real `mix new` project — `check_valid_project`, `project_apps`, `fetch_mix_releases`, `release_apps_by_release_name` all return correct values