### PR TITLE
fix(aws_load_balancer): force sweet_xml compile order

### DIFF
--- a/lib/deploy_ex/aws_load_balancer.ex
+++ b/lib/deploy_ex/aws_load_balancer.ex
@@ -3,6 +3,20 @@ defmodule DeployEx.AwsLoadBalancer do
   AWS Elastic Load Balancer operations for managing target group registrations.
   """
 
+  # ex_aws_elastic_load_balancing wraps its V2 parser in
+  # `if Code.ensure_loaded?(SweetXml) do` at compile time. If sweet_xml hasn't
+  # compiled when the dep compiled, the parser .beam never exists and ExAws
+  # silently returns raw XML bodies. Fail loudly at compile time so the broken
+  # build is caught instead of producing fragile runtime XML fallbacks.
+  unless Code.ensure_loaded?(ExAws.ElasticLoadBalancingV2.Parsers) do
+    raise CompileError,
+      description:
+        "ExAws.ElasticLoadBalancingV2.Parsers missing — sweet_xml must compile before " <>
+          "ex_aws_elastic_load_balancing. Run: " <>
+          "mix deps.clean ex_aws_elastic_load_balancing ex_aws_s3 --build && " <>
+          "mix deps.compile sweet_xml && mix deps.compile"
+  end
+
   def register_target(target_group_arn, instance_id, port, opts \\ []) do
     region = opts[:region] || DeployEx.Config.aws_region()
 
@@ -102,26 +116,6 @@ defmodule DeployEx.AwsLoadBalancer do
     ])}
   end
 
-  defp handle_health_response({:ok, %{body: body}}) when is_binary(body) do
-    case XmlToMap.naive_map(body) do
-      %{"DescribeTargetHealthResponse" => %{"DescribeTargetHealthResult" => %{"TargetHealthDescriptions" => %{"member" => members}}}} ->
-        targets = members
-        |> List.wrap()
-        |> Enum.map(&parse_target_health/1)
-
-        {:ok, targets}
-
-      %{"DescribeTargetHealthResponse" => %{"DescribeTargetHealthResult" => %{"TargetHealthDescriptions" => nil}}} ->
-        {:ok, []}
-
-      structure ->
-        {:error, ErrorMessage.bad_request(
-          "couldn't parse target health response",
-          %{structure: structure}
-        )}
-    end
-  end
-
   defp handle_health_response({:ok, %{body: %{target_health_descriptions: descriptions}}}) do
     targets = descriptions
     |> List.wrap()
@@ -147,26 +141,6 @@ defmodule DeployEx.AwsLoadBalancer do
     ])}
   end
 
-  defp handle_target_groups_response({:ok, %{body: body}}) when is_binary(body) do
-    case XmlToMap.naive_map(body) do
-      %{"DescribeTargetGroupsResponse" => %{"DescribeTargetGroupsResult" => %{"TargetGroups" => %{"member" => members}}}} ->
-        target_groups = members
-        |> List.wrap()
-        |> Enum.map(&parse_target_group/1)
-
-        {:ok, target_groups}
-
-      %{"DescribeTargetGroupsResponse" => %{"DescribeTargetGroupsResult" => %{"TargetGroups" => nil}}} ->
-        {:ok, []}
-
-      structure ->
-        {:error, ErrorMessage.bad_request(
-          "couldn't parse target groups response",
-          %{structure: structure}
-        )}
-    end
-  end
-
   defp handle_target_groups_response({:ok, %{body: %{target_groups: target_groups}}}) do
     parsed = Enum.map(target_groups, fn tg ->
       %{
@@ -189,29 +163,6 @@ defmodule DeployEx.AwsLoadBalancer do
       "error describing target groups",
       %{error_body: body}
     ])}
-  end
-
-  defp parse_target_health(member) do
-    %{
-      id: get_in(member, ["Target", "Id"]),
-      port: get_in(member, ["Target", "Port"]) |> parse_integer(),
-      state: get_in(member, ["TargetHealth", "State"]),
-      reason: get_in(member, ["TargetHealth", "Reason"]),
-      description: get_in(member, ["TargetHealth", "Description"])
-    }
-  end
-
-  defp parse_target_group(member) do
-    %{
-      arn: member["TargetGroupArn"],
-      name: member["TargetGroupName"],
-      port: member["Port"] |> parse_integer(),
-      protocol: member["Protocol"],
-      vpc_id: member["VpcId"],
-      health_check_path: member["HealthCheckPath"],
-      health_check_port: member["HealthCheckPort"],
-      health_check_protocol: member["HealthCheckProtocol"]
-    }
   end
 
   defp parse_integer(nil), do: nil

--- a/mix.exs
+++ b/mix.exs
@@ -7,14 +7,26 @@ defmodule DeployEx.MixProject do
       version: "0.1.0",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      aliases: aliases()
     ]
   end
 
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:ssh, :logger]
+      extra_applications: [:ssh, :logger, :sweet_xml]
+    ]
+  end
+
+  # ex_aws_elastic_load_balancing and ex_aws_s3 wrap their XML parsers in
+  # `if Code.ensure_loaded?(SweetXml) do` at compile time. If sweet_xml has not
+  # been compiled when those deps compile, the parser modules never get built
+  # and ExAws returns raw XML binary bodies at runtime. Force sweet_xml first
+  # so the parsers always exist.
+  defp aliases do
+    [
+      "deps.compile": ["deps.compile sweet_xml", "deps.compile"]
     ]
   end
 


### PR DESCRIPTION
## Summary

- `ex_aws_elastic_load_balancing` and `ex_aws_s3` wrap their XML parsers in `if Code.ensure_loaded?(SweetXml) do` at **compile time**. When `sweet_xml` hadn't been compiled yet (fresh checkouts, `mix deps.clean`, CI), the parser `.beam` was never generated and `ExAws.request/1` silently returned raw XML bodies.
- `AwsLoadBalancer` worked around the symptom with parallel handler clauses (`is_binary(body)` → `XmlToMap.naive_map/1` + `%{body: %{target_groups: …}}` → SweetXml-parsed map). The two paths drifted, producing the recurring "load order" failures.

## Changes

- **`mix.exs`**: `aliases: ["deps.compile": ["deps.compile sweet_xml", "deps.compile"]]` forces `sweet_xml` to compile before `ex_aws_*` so the parser modules always exist.
- **`mix.exs`**: `:sweet_xml` added to `extra_applications` for runtime safety.
- **`lib/deploy_ex/aws_load_balancer.ex`**: compile-time `unless Code.ensure_loaded?(ExAws.ElasticLoadBalancingV2.Parsers)` assertion raises `CompileError` with a clear remediation command if the parser module is ever missing.
- **`lib/deploy_ex/aws_load_balancer.ex`**: deleted the `is_binary(body)` fallback handlers + orphaned `parse_target_health/1` and `parse_target_group/1` helpers — dead code once the parser is guaranteed. Net `-65 / +28`.

## Test plan

- [x] `mix compile --warnings-as-errors --force` — clean
- [x] Stress test: `mix deps.clean sweet_xml ex_aws_elastic_load_balancing ex_aws_s3 --build && mix compile` — `sweet_xml` compiles first, then `ex_aws_s3`, then `ex_aws_elastic_load_balancing`; both parser `.beam` files generated
- [x] `mix test` — 322 tests, same 9 pre-existing failures in `aws_infrastructure_test.exs` (unrelated to load balancer)
- [ ] Exercise on a deploy host: `mix deploy_ex.load_balancer.health` against a real target group to confirm `:ok` path still returns parsed map shape