### PR TITLE
feat(qa.create): default to CI build, auto-install QA deploy step

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ For SSH and ops commands, see [SSH (Eval Pattern)](#ssh-eval-pattern) below.
 - **Git** (required for change detection)
 - **Terraform / OpenTofu** — auto-installed on macOS, Debian/Ubuntu, Alpine, Amazon Linux
 - **Ansible** — auto-installed via pip3 if missing
-- **`gh` CLI** — only needed for `--wait-for-build`; auto-installed when invoked
+- **`gh` CLI** — required by the default CI build flow on `qa.create` (skipped with `--use-local-build`); auto-installed when invoked
 - **AWS credentials** — env vars, AWS CLI profile, or instance role
 - **Windows** is not supported. Use WSL.
 
@@ -324,9 +324,10 @@ The full schema (templates, scheduled scaling, EBS pool, multi-Launch-Template s
 Ephemeral EC2 instances for testing specific SHAs:
 
 ```bash
-mix deploy_ex.qa.create my_app                                       # prompt for SHA
+mix deploy_ex.qa.create my_app                                       # prompt for SHA, CI build (default)
 mix deploy_ex.qa.create my_app --sha abc1234 --tag canary --attach-lb
-mix deploy_ex.qa.create my_app --public-ip-cert --wait-for-build     # CI-gated, public-IP TLS
+mix deploy_ex.qa.create my_app --public-ip-cert --tag canary         # CI-gated, public-IP TLS
+mix deploy_ex.qa.create my_app --use-local-build                     # opt out of CI build
 mix deploy_ex.qa.deploy my_app --sha def5678
 mix deploy_ex.qa.list
 mix deploy_ex.qa.destroy my_app
@@ -335,7 +336,7 @@ mix deploy_ex.qa.cleanup --dry-run
 
 `--public-ip-cert` issues a Let's Encrypt cert via HTTP-01 and triggers an LLM-assisted rewrite of host config so the node serves traffic from its public IP. Originals are restored automatically by `qa.destroy`. Requires `:llm_provider` configured.
 
-`--wait-for-build` commits + pushes the rewrites to a QA branch, finds the matching GitHub Actions workflow (parsing `on.push.branches` globs and looking for jobs that run `mix deploy_ex.release`), waits up to `--build-timeout` minutes, and prompts a 4-option recovery menu on failure (rollback / leave / destroy node only / revert + repush).
+By default `qa.create` commits + pushes the rewrites to a QA branch, finds the matching GitHub Actions workflow (parsing `on.push.branches` globs and looking for jobs that run `mix deploy_ex.release`), patches it with a `Deploy to QA Node` step that runs after the build, waits up to `--build-timeout` minutes for the build, and prompts a 4-option recovery menu on failure (rollback / leave / destroy node only / revert + repush). Pass `--use-local-build` to fall back to a locally-built release.
 
 See [QA Nodes guide](guides/how-to/qa_nodes.md) for the full flow.
 
@@ -389,7 +390,7 @@ The [`guides/`](guides/) folder is the canonical documentation:
 - **Tutorial** — [Getting Started](guides/tutorials/getting_started.md) (covers multi-Phoenix-app config)
 - **How-to**
   - [Deploying Releases](guides/how-to/deploying_releases.md)
-  - [QA Nodes](guides/how-to/qa_nodes.md) — including `--wait-for-build`, public-IP TLS, QA tag schema
+  - [QA Nodes](guides/how-to/qa_nodes.md) — including CI build flow / `--use-local-build`, public-IP TLS, QA tag schema
   - [Connecting to Nodes](guides/how-to/connecting_to_nodes.md) — SSH, eval pattern, alias recipes
   - [Managing Infrastructure](guides/how-to/managing_infrastructure.md) — terraform, priv upgrades, EBS, teardown
   - [Autoscaling](guides/how-to/autoscaling.md) — scale, refresh, deployment strategies

--- a/guides/explanation/architecture.md
+++ b/guides/explanation/architecture.md
@@ -208,7 +208,7 @@ sequenceDiagram
         Dev->>Rewrite: accept/reject
     end
     Dev->>Node: create_instance(SHA, params)
-    opt --wait-for-build
+    opt default (CI build), skipped by --use-local-build
         Dev->>Git: commit_and_push QA branch
         Dev->>GHA: find_build_workflow + wait_for_run
         GHA->>Dev: success | failure (4-option recovery)
@@ -233,7 +233,7 @@ stateDiagram-v2
     Creating --> Running: EC2 launched
     Running --> SetupComplete: ansible.setup
     SetupComplete --> Deployed: ansible.deploy
-    Deployed --> WaitingBuild: --wait-for-build
+    Deployed --> WaitingBuild: default (skipped by --use-local-build)
     WaitingBuild --> Deployed: build success
     WaitingBuild --> RecoveryPrompt: build failure
     RecoveryPrompt --> Terminated: rollback
@@ -279,7 +279,7 @@ flowchart LR
     Plat --> Win
 ```
 
-`mix ansible.deploy` and `mix deploy_ex.qa.create --wait-for-build` call `ToolInstaller.ensure_installed(:ansible)` and `:gh` respectively before doing real work.
+`mix ansible.deploy` and the default CI flow on `mix deploy_ex.qa.create` (skipped only when `--use-local-build` is passed) call `ToolInstaller.ensure_installed(:ansible)` and `:gh` respectively before doing real work.
 
 ## See also
 

--- a/guides/how-to/qa_nodes.md
+++ b/guides/how-to/qa_nodes.md
@@ -32,24 +32,29 @@ Requirements:
 
 Pass `--skip-host-rewrite` to keep the existing config unchanged.
 
-## CI-Gated Deploys (`--wait-for-build`)
+## CI-Gated Deploys (default)
 
-For end-to-end QA flows where the release tarball is built by GitHub Actions (not locally), pass `--wait-for-build`. deploy_ex commits and pushes the SSL/host rewrites to a QA branch, finds the release workflow, and blocks until the build completes.
+`mix deploy_ex.qa.create` defaults to a CI-gated flow: it commits + pushes the SSL/host rewrites to a QA branch, finds the matching release workflow, and blocks until the build completes before deploying. Pass `--use-local-build` to opt out and use a locally-built release instead.
 
 ```bash
-mix deploy_ex.qa.create my_app --public-ip-cert --wait-for-build --tag canary
+mix deploy_ex.qa.create my_app --public-ip-cert --tag canary       # CI build (default)
+mix deploy_ex.qa.create my_app --use-local-build --tag canary      # local build
 ```
 
-**Workflow detection:** scans `.github/workflows/*.yml` for the workflow whose `on.push.branches` glob matches the QA branch and whose jobs (or sub-workflow jobs) run `mix deploy_ex.release`.
+While running in the default flow, qa.create also idempotently patches the detected workflow yml to add a `Deploy to QA Node` step that runs `mix deploy_ex.qa.deploy --git-branch <branch>` on QA refs, and guards the existing `Run Ansible Deploy` step so it skips on QA branches. Patches are marked with sentinel comments and committed to the QA branch alongside the host rewrites. Pass `--skip-action-install` to opt out of just the workflow patch.
+
+**Workflow detection:** scans `.github/workflows/*.yml` for the workflow whose `on.push.branches` glob matches the QA branch and whose jobs (or sub-workflow jobs) run `mix deploy_ex.release`. Hard-errors with a hint to pass `--use-local-build` if none match.
 
 **Branch resolution:**
 - Current branch matches `^qa[\/-]` → reuse it
 - Otherwise → derive `qa/<app>-<tag>` (or `qa/<app>-<short_sha>` if `--tag` is omitted)
 
 **Override flags:**
+- `--use-local-build` — opt out of CI build, deploy a locally-built release
 - `--build-workflow=<file>` — bypass auto-detection
 - `--build-job=<job_id>` — narrow to one job inside the workflow
 - `--build-timeout=<minutes>` — wait cap (default `30`)
+- `--skip-action-install` — keep the workflow yml untouched (don't install the QA-deploy step)
 
 **On build failure** the task prompts you to choose:
 1. Destroy QA node + revert (full rollback)

--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -15,7 +15,7 @@ It supports both **umbrella** and **single-app** Elixir projects.
 - **Load testing** — k6 runner instances with Prometheus metrics integration
 - **Monitoring** — Optional Grafana UI, Loki logs, Prometheus metrics, Sentry, Redis, Postgres
 - **TUI** — Interactive terminal wizard, progress streams, and per-hunk diff viewer
-- **CI integration** — `gh` CLI workflow detection, branch matching, and `--wait-for-build` gating for QA flows
+- **CI integration** — `gh` CLI workflow detection, branch matching, and CI-build gating (default) on QA flows
 
 ## Project Structure
 
@@ -71,7 +71,7 @@ guides/                              # Documentation (this folder)
 | `DeployEx.ReleaseUploader` | Coordinates release discovery, validation, S3 upload |
 | `DeployEx.QaNode` | QA instance lifecycle and S3 state |
 | `DeployEx.ChangePlanner` | Priv-upgrade diff planning (rename/split/merge) |
-| `DeployEx.GitHubActions` | Workflow detection + run polling for `--wait-for-build` |
+| `DeployEx.GitHubActions` | Workflow detection + run polling for the default CI build flow on `qa.create` |
 | `DeployEx.Terraform` | Terraform CLI argument parsing and command execution |
 
 ## Getting Started Flow

--- a/guides/reference/mix_tasks.md
+++ b/guides/reference/mix_tasks.md
@@ -178,14 +178,16 @@ Overview / quick start (no flags).
 - `--use-ami` — boot from app AMI
 - `--attach-lb` — register with load balancer after deploy
 - `--public-ip-cert` — Let's Encrypt cert + LLM-assisted host rewrite
-- `--wait-for-build` — commit + push QA branch, wait for GitHub Actions
+- `--use-local-build` — opt out of CI build wait; build + deploy locally
 - `--build-workflow <file>` / `--build-job <id>` / `--build-timeout <minutes>` (default 30)
+- `--skip-action-install` — skip the workflow yml patch that installs the QA-deploy step
 - `-f force`, `-q quiet`, `--no-tui`
 - `--aws-region`, `--aws-release-bucket`
 
 ### `mix deploy_ex.qa.deploy <app>`
 - `-s, --sha` (required outside TUI mode)
 - `-i, --instance-id` — pick a specific QA node
+- `--git-branch <branch>` — auto-select QA node by branch (non-interactive)
 - `--public-ip-cert` / `--no-public-ip-cert` — toggle cert mode (persisted to state)
 - `-q quiet`, `--aws-region`, `--aws-release-bucket`
 

--- a/guides/tutorials/getting_started.md
+++ b/guides/tutorials/getting_started.md
@@ -8,7 +8,7 @@ This tutorial walks you through setting up deploy_ex from scratch and deploying 
 - **Ansible** — server configuration. Auto-installed via pip3 if missing.
 - **Git** — required for change detection.
 - **AWS credentials** — env vars, AWS CLI profile, or instance role.
-- **`gh` CLI** — only needed if you use `--wait-for-build` on `mix deploy_ex.qa.create`. Auto-installed when invoked.
+- **`gh` CLI** — used by the default CI build flow on `mix deploy_ex.qa.create` (pass `--use-local-build` to skip it). Auto-installed when invoked.
 
 ## Step 1: Install
 
@@ -142,7 +142,7 @@ Same pattern for `tailwind` and `dart_sass`. `mix deploy_ex.release` discovers t
 ## Next Steps
 
 - [How to Deploy Releases](../how-to/deploying_releases.md) — rollback, target specific apps, CI/CD
-- [How to Use QA Nodes](../how-to/qa_nodes.md) — ephemeral test instances + `--wait-for-build`
+- [How to Use QA Nodes](../how-to/qa_nodes.md) — ephemeral test instances + CI build flow
 - [How to Manage Infrastructure](../how-to/managing_infrastructure.md) — terraform, priv upgrades, EBS snapshots
 - [How to Set Up Monitoring](../how-to/monitoring.md) — Grafana, Loki, Prometheus, Sentry
 - [How to Cluster Your Nodes](../how-to/clustering.md) — libcluster + EC2Tag strategy

--- a/lib/deploy_ex/github_actions/qa_deploy_step_installer.ex
+++ b/lib/deploy_ex/github_actions/qa_deploy_step_installer.ex
@@ -1,0 +1,247 @@
+defmodule DeployEx.GitHubActions.QaDeployStepInstaller do
+  @moduledoc """
+  Idempotently patches a GitHub Actions workflow file so that QA branch builds
+  trigger `mix deploy_ex.qa.deploy` after the upload step, and so the existing
+  `mix ansible.deploy` step skips on QA branches.
+
+  Modifies the file as text — preserves user comments, ordering, and whitespace
+  outside the managed regions. Sentinel comments mark every managed edit so
+  re-runs are no-ops:
+
+    * `# deploy_ex:qa-deploy:begin` / `# deploy_ex:qa-deploy:end` — wrap the
+      inserted "Deploy to QA Node" step.
+    * `# deploy_ex:qa-skip` — trailing marker on the managed `if:` guard for
+      the existing `mix ansible.deploy` step.
+
+  Result map fields:
+
+    * `:qa_step` — `:inserted` | `:already_installed`
+    * `:ansible_guard` — `:inserted` | `:already_installed` |
+      `:skipped_user_managed` (step has a non-managed `if:`) |
+      `:not_applicable` (no `mix ansible.deploy` step present)
+
+  Errors:
+
+    * `:not_found` — workflow file does not exist.
+    * `:unprocessable_entity` — anchor step (`mix deploy_ex.upload`) is missing,
+      so we cannot place the QA-deploy step deterministically.
+  """
+
+  @qa_step_begin_marker "# deploy_ex:qa-deploy:begin"
+  @qa_step_end_marker "# deploy_ex:qa-deploy:end"
+  @ansible_guard_marker "# deploy_ex:qa-skip"
+  @anchor_signature "mix deploy_ex.upload"
+  @ansible_step_name_signature "Run Ansible Deploy"
+
+  @type install_result :: %{
+          qa_step: :inserted | :already_installed,
+          ansible_guard:
+            :inserted | :already_installed | :skipped_user_managed | :not_applicable
+        }
+
+  @spec install(Path.t()) :: {:ok, install_result} | {:error, ErrorMessage.t()}
+  def install(workflow_path) do
+    with {:ok, contents} <- read_workflow(workflow_path),
+         {:ok, with_qa_step, qa_status} <- ensure_qa_step(contents),
+         {:ok, final_contents, guard_status} <- ensure_ansible_guard(with_qa_step) do
+      write_if_changed(workflow_path, contents, final_contents)
+      {:ok, %{qa_step: qa_status, ansible_guard: guard_status}}
+    end
+  end
+
+  @spec installed?(Path.t()) :: boolean()
+  def installed?(workflow_path) do
+    case File.read(workflow_path) do
+      {:ok, contents} -> qa_step_present?(contents)
+      {:error, _reason} -> false
+    end
+  end
+
+  defp read_workflow(path) do
+    case File.read(path) do
+      {:ok, contents} ->
+        {:ok, contents}
+
+      {:error, reason} ->
+        {:error,
+         ErrorMessage.not_found(
+           "workflow file not readable: #{path}",
+           %{path: path, reason: reason}
+         )}
+    end
+  end
+
+  defp ensure_qa_step(contents) do
+    cond do
+      qa_step_present?(contents) ->
+        {:ok, contents, :already_installed}
+
+      anchor_line = find_anchor_step_block_end(contents) ->
+        {:ok, insert_qa_step_after(contents, anchor_line), :inserted}
+
+      true ->
+        {:error,
+         ErrorMessage.unprocessable_entity(
+           "workflow has no `#{@anchor_signature}` step; cannot place QA-deploy step",
+           %{anchor: @anchor_signature}
+         )}
+    end
+  end
+
+  defp qa_step_present?(contents) do
+    String.contains?(contents, @qa_step_begin_marker) and
+      String.contains?(contents, @qa_step_end_marker)
+  end
+
+  defp find_anchor_step_block_end(contents) do
+    lines = String.split(contents, "\n")
+
+    case Enum.find_index(lines, &String.contains?(&1, @anchor_signature)) do
+      nil -> nil
+      idx -> last_line_of_step_starting_around(lines, idx)
+    end
+  end
+
+  defp last_line_of_step_starting_around(lines, anchor_idx) do
+    step_start_idx = step_start_idx_at_or_before(lines, anchor_idx)
+    step_indent = leading_space_count(Enum.at(lines, step_start_idx))
+    next_step_idx = next_step_or_eof_idx(lines, step_start_idx + 1, step_indent)
+    %{step_start: step_start_idx, insert_after: next_step_idx - 1, step_indent: step_indent}
+  end
+
+  defp step_start_idx_at_or_before(lines, idx) do
+    Enum.reduce_while(idx..0//-1, idx, fn i, _acc ->
+      if step_header_line?(Enum.at(lines, i)), do: {:halt, i}, else: {:cont, idx}
+    end)
+  end
+
+  defp step_header_line?(line) when is_binary(line) do
+    Regex.match?(~r/^\s*-\s+(name:|uses:|run:|id:)/, line)
+  end
+
+  defp step_header_line?(_), do: false
+
+  defp next_step_or_eof_idx(lines, from_idx, step_indent) do
+    total = length(lines)
+
+    Enum.reduce_while(from_idx..(total - 1), total, fn i, _acc ->
+      line = Enum.at(lines, i)
+
+      if step_header_line?(line) and leading_space_count(line) === step_indent do
+        {:halt, i}
+      else
+        {:cont, total}
+      end
+    end)
+  end
+
+  defp leading_space_count(line) when is_binary(line) do
+    line |> String.graphemes() |> Enum.take_while(&(&1 === " ")) |> length()
+  end
+
+  defp leading_space_count(_), do: 0
+
+  defp insert_qa_step_after(contents, %{insert_after: insert_idx, step_indent: indent}) do
+    lines = String.split(contents, "\n")
+    {before_lines, after_lines} = Enum.split(lines, insert_idx + 1)
+    qa_block = qa_step_lines(indent)
+    Enum.join(before_lines ++ qa_block ++ after_lines, "\n")
+  end
+
+  defp qa_step_lines(indent) do
+    pad = String.duplicate(" ", indent)
+    inner = String.duplicate(" ", indent + 2)
+    run = String.duplicate(" ", indent + 4)
+
+    [
+      "",
+      pad <> @qa_step_begin_marker,
+      pad <> "- name: Deploy to QA Node",
+      inner <> "if: ${{ startsWith(github.ref, 'refs/heads/qa/') || startsWith(github.ref, 'refs/heads/qa-') }}",
+      inner <> "run: |",
+      run <> "branch_name=\"${GITHUB_REF#refs/heads/}\"",
+      run <> "app_name=$(echo \"$branch_name\" | sed -E 's|^qa[/-]||; s|-[^-]+$||')",
+      run <> "mix deploy_ex.qa.deploy \"$app_name\" \\",
+      run <> "  --sha $(git rev-parse --short ${{ github.sha }}) \\",
+      run <> "  --git-branch \"$branch_name\" \\",
+      run <> "  --no-tui --quiet",
+      pad <> @qa_step_end_marker
+    ]
+  end
+
+  defp ensure_ansible_guard(contents) do
+    lines = String.split(contents, "\n")
+
+    case find_ansible_step(lines) do
+      nil ->
+        {:ok, contents, :not_applicable}
+
+      %{name_idx: name_idx} = step ->
+        evaluate_ansible_step(contents, lines, name_idx, step)
+    end
+  end
+
+  defp evaluate_ansible_step(contents, lines, name_idx, step) do
+    cond do
+      ansible_guard_marker_present?(lines, step) ->
+        {:ok, contents, :already_installed}
+
+      user_managed_if?(lines, step) ->
+        {:ok, contents, :skipped_user_managed}
+
+      true ->
+        new_contents = insert_ansible_guard(lines, name_idx, step.indent)
+        {:ok, new_contents, :inserted}
+    end
+  end
+
+  defp find_ansible_step(lines) do
+    name_idx =
+      Enum.find_index(lines, fn line ->
+        Regex.match?(~r/^\s*-\s+name:\s+#{@ansible_step_name_signature}\b/, line)
+      end)
+
+    case name_idx do
+      nil ->
+        nil
+
+      idx ->
+        line = Enum.at(lines, idx)
+        indent = leading_space_count(line)
+        next_idx = next_step_or_eof_idx(lines, idx + 1, indent)
+        %{name_idx: idx, indent: indent, end_idx: next_idx - 1}
+    end
+  end
+
+  defp ansible_guard_marker_present?(lines, %{name_idx: name_idx, end_idx: end_idx}) do
+    lines
+    |> Enum.slice(name_idx..end_idx)
+    |> Enum.any?(&String.contains?(&1, @ansible_guard_marker))
+  end
+
+  defp user_managed_if?(lines, %{name_idx: name_idx, end_idx: end_idx, indent: indent}) do
+    inner_indent = indent + 2
+    if_prefix = String.duplicate(" ", inner_indent) <> "if:"
+
+    lines
+    |> Enum.slice((name_idx + 1)..end_idx)
+    |> Enum.any?(&String.starts_with?(&1, if_prefix))
+  end
+
+  defp insert_ansible_guard(lines, name_idx, indent) do
+    pad = String.duplicate(" ", indent + 2)
+
+    guard_line =
+      "#{pad}if: ${{ !startsWith(github.ref, 'refs/heads/qa/') && !startsWith(github.ref, 'refs/heads/qa-') }}  #{@ansible_guard_marker}"
+
+    {before_lines, after_lines} = Enum.split(lines, name_idx + 1)
+    Enum.join(before_lines ++ [guard_line] ++ after_lines, "\n")
+  end
+
+  defp write_if_changed(_path, contents, contents), do: :ok
+
+  defp write_if_changed(path, _old, new_contents) do
+    File.write!(path, new_contents)
+    :ok
+  end
+end

--- a/lib/deploy_ex/qa_node.ex
+++ b/lib/deploy_ex/qa_node.ex
@@ -542,6 +542,36 @@ defmodule DeployEx.QaNode do
     end
   end
 
+  @doc """
+  Selects the single QA node whose `git_branch` matches `branch`. Used for
+  non-interactive callers (CI, GitHub Actions) where prompting is unavailable.
+
+  Returns `{:error, ErrorMessage.not_found/2}` when no node is on `branch`, and
+  `{:error, ErrorMessage.conflict/2}` when more than one node shares the
+  branch — the caller must disambiguate by `--instance-id`.
+  """
+  @spec select_by_branch([t()], String.t()) :: {:ok, t()} | {:error, ErrorMessage.t()}
+  def select_by_branch(nodes, branch) do
+    case Enum.filter(nodes, &(&1.git_branch === branch)) do
+      [node] ->
+        {:ok, node}
+
+      [] ->
+        {:error,
+         ErrorMessage.not_found(
+           "no QA node found on branch #{branch}",
+           %{branch: branch, available_branches: Enum.map(nodes, & &1.git_branch)}
+         )}
+
+      multiple ->
+        {:error,
+         ErrorMessage.conflict(
+           "multiple QA nodes found on branch #{branch}; disambiguate with --instance-id",
+           %{branch: branch, instance_ids: Enum.map(multiple, & &1.instance_id)}
+         )}
+    end
+  end
+
   def find_qa_node_from_ec2(app_name, opts \\ []) do
     region = opts[:region] || DeployEx.Config.aws_region()
     environment = opts[:environment] || DeployEx.Config.env()

--- a/lib/deploy_ex/tui/wizard/command_registry.ex
+++ b/lib/deploy_ex/tui/wizard/command_registry.ex
@@ -483,10 +483,11 @@ defmodule DeployEx.TUI.Wizard.CommandRegistry do
         input(:quiet, "Quiet", :boolean),
         input(:aws_region, "AWS region", :string),
         input(:aws_release_bucket, "AWS release bucket", :string),
-        input(:wait_for_build, "Wait for build", :boolean, description: "Wait for the GitHub Actions build to finish before creating"),
+        input(:use_local_build, "Use local build", :boolean, description: "Opt out of the default CI build wait; build + deploy locally"),
         input(:build_workflow, "Build workflow", :string, description: "GitHub Actions workflow file (e.g. release.yml)"),
         input(:build_job, "Build job", :string, description: "GitHub Actions job name to wait on"),
-        input(:build_timeout, "Build timeout (s)", :integer, description: "Timeout in seconds when waiting for the build")
+        input(:build_timeout, "Build timeout (s)", :integer, description: "Timeout in seconds when waiting for the build"),
+        input(:skip_action_install, "Skip GitHub Action install", :boolean, description: "Skip the workflow yml patch that installs the QA-deploy step")
       ]
     },
     %{
@@ -526,6 +527,7 @@ defmodule DeployEx.TUI.Wizard.CommandRegistry do
         ),
         input(:sha, "Git SHA", :string),
         input(:instance_id, "Instance ID", :string, description: "Target a specific QA instance when multiple exist"),
+        input(:git_branch, "Git branch", :string, description: "Auto-select QA node by git_branch (non-interactive)"),
         input(:public_ip_cert, "Public IP cert", :boolean, description: "Toggle public-IP LE cert mode"),
         input(:quiet, "Quiet", :boolean),
         input(:aws_region, "AWS region", :string),

--- a/lib/mix/tasks/deploy_ex.qa.create.ex
+++ b/lib/mix/tasks/deploy_ex.qa.create.ex
@@ -19,23 +19,37 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
   mix deploy_ex.qa.create my_app --sha abc1234 --use-ami
   ```
 
-  ## Wait for build (CI-gated deploys)
+  ## CI build flow (default)
 
-  Pass `--wait-for-build` to commit + push the SSL/host rewrites and wait for
-  GitHub Actions to build the release artifact before deploying.
+  By default, qa.create commits + pushes the SSL/host rewrites and waits for
+  GitHub Actions to build the release artifact before deploying. Pass
+  `--use-local-build` to opt out and use a locally-built release instead.
 
-      mix deploy_ex.qa.create cfx_web --public-ip-cert --wait-for-build --tag canary
+      mix deploy_ex.qa.create cfx_web --public-ip-cert --tag canary
+      mix deploy_ex.qa.create cfx_web --use-local-build           # local build path
 
   Detection: scans `.github/workflows/*.yml` for the workflow whose `on.push.branches`
   matches the QA branch and whose jobs (or sub-workflow jobs) run `mix deploy_ex.release`.
+  Hard-errors when no workflow matches; pass `--use-local-build` if you don't have one.
 
   Branch resolution: if the current branch matches `^qa[\/-]` it is reused; otherwise
   derives `qa/<app>-<tag>` (or `qa/<app>-<short_sha>` if `--tag` is omitted).
 
+  ### Auto-installed QA deploy step
+
+  In the default (CI build) flow, qa.create idempotently patches the detected
+  workflow so the build job ends with a `Deploy to QA Node` step that runs
+  `mix deploy_ex.qa.deploy --git-branch <branch>` for QA refs. The existing
+  `Run Ansible Deploy` step is guarded so it skips on QA branches. The patch is
+  marked with sentinel comments (`# deploy_ex:qa-deploy:*`) and is a no-op on
+  subsequent runs. Pass `--skip-action-install` to opt out of just the patch.
+
   Options:
+    --use-local-build         Skip the CI build wait; build + deploy locally
     --build-workflow=<file>   Override workflow auto-detection
     --build-job=<job_id>      Override job auto-detection within the workflow
     --build-timeout=<minutes> Default 30. Max wait for the build to complete
+    --skip-action-install     Skip the workflow yml patch that installs the QA-deploy step
 
   On build failure, prompts with 4 options:
     1. Destroy QA node + revert (full rollback)
@@ -138,9 +152,11 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
     end
   end
 
-  defp validate_wait_for_build_preconditions(_opts, _umbrella_root, _app_name, false), do: {:ok, %{enabled?: false}}
+  defp ci_build_enabled?(opts), do: not (opts[:use_local_build] || false)
 
-  defp validate_wait_for_build_preconditions(opts, umbrella_root, app_name, true) do
+  defp validate_ci_build_preconditions(_opts, _umbrella_root, _app_name, false), do: {:ok, %{enabled?: false}}
+
+  defp validate_ci_build_preconditions(opts, umbrella_root, app_name, true) do
     with :ok <- DeployEx.ToolInstaller.ensure_installed(:gh),
          :ok <- DeployEx.GitHubActions.ensure_authenticated(),
          {:ok, branch_resolution} <- resolve_branch(opts, umbrella_root, app_name),
@@ -162,9 +178,21 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
         {:ok, %{file: wf, job_id: job}}
 
       _ ->
-        DeployEx.GitHubActions.find_build_workflow(workflows_root, branch)
+        workflows_root
+        |> DeployEx.GitHubActions.find_build_workflow(branch)
+        |> hint_use_local_build_on_not_found()
     end
   end
+
+  defp hint_use_local_build_on_not_found({:error, %ErrorMessage{code: :not_found} = err}) do
+    hinted =
+      err.message <>
+        "\n\nPass --use-local-build if you don't have a CI workflow that runs mix deploy_ex.release for QA branches."
+
+    {:error, %{err | message: hinted}}
+  end
+
+  defp hint_use_local_build_on_not_found(result), do: result
 
   defp resolve_branch(opts, umbrella_root, app_name) do
     sha = opts[:sha] || head_sha(umbrella_root)
@@ -291,11 +319,11 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
     end
   end
 
-  @pipeline_total_steps_base 12
-  @pipeline_total_steps_wait_for_build 15
+  @pipeline_total_steps_local 12
+  @pipeline_total_steps_ci 15
 
   defp pipeline_total_steps(opts) do
-    if opts[:wait_for_build], do: @pipeline_total_steps_wait_for_build, else: @pipeline_total_steps_base
+    if ci_build_enabled?(opts), do: @pipeline_total_steps_ci, else: @pipeline_total_steps_local
   end
 
   defp step_for(:validate_app, _opts), do: 1
@@ -303,16 +331,16 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
   defp step_for(:plan_rewrite, _opts), do: 3
   defp step_for(:review_proposals, _opts), do: 4
   defp step_for(:preflight_build, _opts), do: 5
-  defp step_for(:gather_infra, opts), do: if(opts[:wait_for_build], do: 6, else: 5)
-  defp step_for(:create_node, opts), do: if(opts[:wait_for_build], do: 7, else: 6)
-  defp step_for(:wait_instance, opts), do: if(opts[:wait_for_build], do: 8, else: 7)
-  defp step_for(:save_state, opts), do: if(opts[:wait_for_build], do: 9, else: 8)
-  defp step_for(:apply_rewrite, opts), do: if(opts[:wait_for_build], do: 10, else: 9)
+  defp step_for(:gather_infra, opts), do: if(ci_build_enabled?(opts), do: 6, else: 5)
+  defp step_for(:create_node, opts), do: if(ci_build_enabled?(opts), do: 7, else: 6)
+  defp step_for(:wait_instance, opts), do: if(ci_build_enabled?(opts), do: 8, else: 7)
+  defp step_for(:save_state, opts), do: if(ci_build_enabled?(opts), do: 9, else: 8)
+  defp step_for(:apply_rewrite, opts), do: if(ci_build_enabled?(opts), do: 10, else: 9)
   defp step_for(:commit_push, _opts), do: 11
   defp step_for(:wait_build, _opts), do: 12
-  defp step_for(:wait_ssh, opts), do: if(opts[:wait_for_build], do: 13, else: 10)
-  defp step_for(:setup_deploy, opts), do: if(opts[:wait_for_build], do: 14, else: 11)
-  defp step_for(:attach_lb, opts), do: if(opts[:wait_for_build], do: 15, else: 12)
+  defp step_for(:wait_ssh, opts), do: if(ci_build_enabled?(opts), do: 13, else: 10)
+  defp step_for(:setup_deploy, opts), do: if(ci_build_enabled?(opts), do: 14, else: 11)
+  defp step_for(:attach_lb, opts), do: if(ci_build_enabled?(opts), do: 15, else: 12)
 
   defp run_qa_pipeline_work(tui_pid, app_name, sha, opts) do
     total_steps = pipeline_total_steps(opts)
@@ -326,13 +354,14 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
          {:ok, full_sha} <- (progress.(:validate_sha, "Validating SHA..."); validate_and_find_sha(app_name, sha, opts)),
          {:ok, plan} <- (progress.(:plan_rewrite, "Planning host config rewrite (LLM)..."); maybe_plan_host_rewrite(app_name, opts)),
          {:ok, accepted} <- (progress.(:review_proposals, "Confirming target files..."); maybe_review_proposals(plan, tui_pid)),
-         {:ok, build_state} <- (maybe_progress_preflight(progress, opts); validate_wait_for_build_preconditions(opts, umbrella_root, app_name, opts[:wait_for_build] || false)),
+         {:ok, build_state} <- (maybe_progress_preflight(progress, opts); validate_ci_build_preconditions(opts, umbrella_root, app_name, ci_build_enabled?(opts))),
          {:ok, infra} <- (progress.(:gather_infra, "Gathering infrastructure..."); gather_infrastructure(app_name, opts)),
          {:ok, qa_node} <- (progress.(:create_node, "Creating QA node..."); create_qa_node(app_name, full_sha, infra, opts)),
          :ok <- (progress.(:wait_instance, "Waiting for instance to start..."); wait_for_instance(qa_node, opts)),
          {:ok, qa_node} <- (progress.(:save_state, "Saving QA state..."); save_and_refresh_state(qa_node, opts)),
          {:ok, entries} <- (progress.(:apply_rewrite, "Applying host config rewrite..."); maybe_apply_proposals(qa_node, plan, accepted)),
-         {:ok, qa_node} <- (maybe_progress_commit_push(progress, opts); commit_and_push_rewrites(qa_node, build_state, entries, opts[:wait_for_build] || false, tui_pid)),
+         {:ok, entries} <- maybe_install_qa_deploy_action(umbrella_root, build_state, entries, opts, tui_pid),
+         {:ok, qa_node} <- (maybe_progress_commit_push(progress, opts); commit_and_push_rewrites(qa_node, build_state, entries, ci_build_enabled?(opts), tui_pid)),
          :ok <- (maybe_progress_wait_build(progress, opts); wait_for_build_step(qa_node, build_state, opts, tui_pid)),
          :ok <- (progress.(:wait_ssh, "Waiting for SSH..."); wait_for_ssh_ready(qa_node, tui_pid)),
          :ok <- (progress.(:setup_deploy, "Running setup & deploy..."); run_setup_and_deploy(qa_node, infra, tui_pid, opts)),
@@ -342,8 +371,8 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
   end
 
   defp maybe_progress_preflight(progress, opts) do
-    if opts[:wait_for_build] do
-      progress.(:preflight_build, "Validating wait-for-build preconditions...")
+    if ci_build_enabled?(opts) do
+      progress.(:preflight_build, "Validating CI build preconditions...")
     else
       :ok
     end
@@ -384,8 +413,47 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
     DeployEx.QaHostRewrite.apply_proposals(accepted, qa_node.public_ip, backup_dir)
   end
 
+  defp maybe_install_qa_deploy_action(umbrella_root, build_state, entries, opts, tui_pid) do
+    cond do
+      not ci_build_enabled?(opts) -> {:ok, entries}
+      opts[:skip_action_install] === true -> {:ok, entries}
+      build_state[:enabled?] !== true -> {:ok, entries}
+      true -> install_qa_deploy_action(umbrella_root, build_state, entries, tui_pid)
+    end
+  end
+
+  defp install_qa_deploy_action(umbrella_root, %{workflow: %{file: file}}, entries, tui_pid) do
+    workflow_path = Path.join([umbrella_root, ".github/workflows", file])
+
+    case DeployEx.GitHubActions.QaDeployStepInstaller.install(workflow_path) do
+      {:ok, %{qa_step: :inserted}} = ok ->
+        log_action_install_status(tui_pid, ok, workflow_path)
+        {:ok, append_workflow_entry(entries, workflow_path)}
+
+      {:ok, %{qa_step: :already_installed}} = ok ->
+        log_action_install_status(tui_pid, ok, workflow_path)
+        {:ok, entries}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp log_action_install_status(tui_pid, {:ok, %{qa_step: status}}, workflow_path) when is_pid(tui_pid) do
+    DeployEx.TUI.Progress.update_log(tui_pid, "  QA deploy step #{status}: #{workflow_path}")
+  end
+
+  defp log_action_install_status(_tui_pid, {:ok, %{qa_step: status}}, workflow_path) do
+    Mix.shell().info([:faint, "QA deploy step #{status}: #{workflow_path}"])
+  end
+
+  defp append_workflow_entry(entries, workflow_path) do
+    relative = Path.relative_to(workflow_path, File.cwd!())
+    entries ++ [%{path: relative}]
+  end
+
   defp maybe_progress_commit_push(progress, opts) do
-    if opts[:wait_for_build] do
+    if ci_build_enabled?(opts) do
       progress.(:commit_push, "Committing & pushing QA branch...")
     else
       :ok
@@ -413,7 +481,7 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
   defp umbrella_root, do: File.cwd!()
 
   defp maybe_progress_wait_build(progress, opts) do
-    if opts[:wait_for_build] do
+    if ci_build_enabled?(opts) do
       progress.(:wait_build, "Waiting for build workflow...")
     else
       :ok
@@ -421,7 +489,7 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
   end
 
   defp wait_for_build_step(qa_node, build_state, opts, tui_pid) do
-    case wait_for_build(qa_node, build_state, opts[:wait_for_build] || false, opts, tui_pid) do
+    case wait_for_build(qa_node, build_state, ci_build_enabled?(opts), opts, tui_pid) do
       {:ok, :skipped} ->
         :ok
 
@@ -525,10 +593,11 @@ defmodule Mix.Tasks.DeployEx.Qa.Create do
         aws_region: :string,
         aws_release_bucket: :string,
         no_tui: :boolean,
-        wait_for_build: :boolean,
+        use_local_build: :boolean,
         build_workflow: :string,
         build_job: :string,
-        build_timeout: :integer
+        build_timeout: :integer,
+        skip_action_install: :boolean
       ]
     )
   end

--- a/lib/mix/tasks/deploy_ex.qa.deploy.ex
+++ b/lib/mix/tasks/deploy_ex.qa.deploy.ex
@@ -9,6 +9,7 @@ defmodule Mix.Tasks.DeployEx.Qa.Deploy do
   ```bash
   mix deploy_ex.qa.deploy my_app --sha def5678
   mix deploy_ex.qa.deploy my_app --sha def5678 --instance-id i-0abc123
+  mix deploy_ex.qa.deploy my_app --sha def5678 --git-branch qa/my_app-canary
   mix deploy_ex.qa.deploy my_app --sha def5678 --public-ip-cert       # enable cert mode
   mix deploy_ex.qa.deploy my_app --sha def5678 --no-public-ip-cert    # disable cert mode
   ```
@@ -16,6 +17,9 @@ defmodule Mix.Tasks.DeployEx.Qa.Deploy do
   ## Options
   - `--sha, -s` - Target git SHA (required)
   - `--instance-id, -i` - Target a specific QA instance when multiple exist
+  - `--git-branch` - Auto-select the QA node whose `git_branch` matches. Required
+    for non-interactive use (GitHub Actions); errors with `:conflict` when more
+    than one node shares the branch.
   - `--public-ip-cert` / `--no-public-ip-cert` - Toggle public-IP Let's Encrypt cert
     mode before the deploy. Updates the `UsePublicIpCert` EC2 tag and S3 state so
     ansible picks up the new mode on this run and every subsequent one. Omit the
@@ -135,12 +139,10 @@ defmodule Mix.Tasks.DeployEx.Qa.Deploy do
   end
 
   defp choose_node_in_terminal(terminal, nodes, app_name, opts) do
-    case opts[:instance_id] do
-      nil ->
-        pick_node_in_terminal(terminal, nodes)
-
-      instance_id ->
-        find_node_by_instance_id(nodes, instance_id, app_name)
+    cond do
+      opts[:instance_id] -> find_node_by_instance_id(nodes, opts[:instance_id], app_name)
+      opts[:git_branch] -> DeployEx.QaNode.select_by_branch(nodes, opts[:git_branch])
+      true -> pick_node_in_terminal(terminal, nodes)
     end
   end
 
@@ -225,6 +227,7 @@ defmodule Mix.Tasks.DeployEx.Qa.Deploy do
       switches: [
         sha: :string,
         instance_id: :string,
+        git_branch: :string,
         public_ip_cert: :boolean,
         quiet: :boolean,
         aws_region: :string,
@@ -254,29 +257,21 @@ defmodule Mix.Tasks.DeployEx.Qa.Deploy do
   end
 
   defp choose_node(nodes, app_name, opts) do
-    case opts[:instance_id] do
-      nil ->
-        case DeployEx.QaNode.pick_interactive(nodes,
-               title: "Select QA node to deploy to",
-               allow_all: false,
-               always_prompt: true
-             ) do
-          {:ok, [picked]} -> {:ok, picked}
-          {:ok, []} -> {:error, ErrorMessage.bad_request("no QA node selected")}
-        end
+    cond do
+      opts[:instance_id] -> find_node_by_instance_id(nodes, opts[:instance_id], app_name)
+      opts[:git_branch] -> DeployEx.QaNode.select_by_branch(nodes, opts[:git_branch])
+      true -> pick_node_interactively(nodes)
+    end
+  end
 
-      instance_id ->
-        case Enum.find(nodes, &(&1.instance_id === instance_id)) do
-          nil ->
-            {:error,
-             ErrorMessage.not_found(
-               "no QA node matching --instance-id #{instance_id} for app '#{app_name}'",
-               %{available_ids: Enum.map(nodes, & &1.instance_id)}
-             )}
-
-          node ->
-            {:ok, node}
-        end
+  defp pick_node_interactively(nodes) do
+    case DeployEx.QaNode.pick_interactive(nodes,
+           title: "Select QA node to deploy to",
+           allow_all: false,
+           always_prompt: true
+         ) do
+      {:ok, [picked]} -> {:ok, picked}
+      {:ok, []} -> {:error, ErrorMessage.bad_request("no QA node selected")}
     end
   end
 

--- a/test/deploy_ex/github_actions/qa_deploy_step_installer_test.exs
+++ b/test/deploy_ex/github_actions/qa_deploy_step_installer_test.exs
@@ -1,0 +1,120 @@
+defmodule DeployEx.GitHubActions.QaDeployStepInstallerTest do
+  use ExUnit.Case, async: true
+
+  alias DeployEx.GitHubActions.QaDeployStepInstaller
+
+  @fixtures_root Path.expand("../../support/fixtures/workflows/installer", __DIR__)
+
+  setup do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "qa_deploy_step_installer_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  describe "install/1" do
+    test "inserts QA deploy step and ansible.deploy guard on fresh workflow", %{tmp_dir: tmp_dir} do
+      path = copy_fixture("fresh.yml", tmp_dir)
+
+      assert {:ok, %{qa_step: :inserted, ansible_guard: :inserted}} ===
+               QaDeployStepInstaller.install(path)
+
+      contents = File.read!(path)
+
+      assert contents =~ "# deploy_ex:qa-deploy:begin"
+      assert contents =~ "# deploy_ex:qa-deploy:end"
+      assert contents =~ "- name: Deploy to QA Node"
+      assert contents =~ "mix deploy_ex.qa.deploy"
+      assert contents =~ "--git-branch"
+      assert contents =~ "# deploy_ex:qa-skip"
+      assert contents =~ ~r/Run Ansible Deploy.*\n\s+if: .*startsWith.*qa\//s
+    end
+
+    test "is idempotent — second run is no-op", %{tmp_dir: tmp_dir} do
+      path = copy_fixture("fresh.yml", tmp_dir)
+
+      {:ok, _} = QaDeployStepInstaller.install(path)
+      first_run = File.read!(path)
+
+      assert {:ok, %{qa_step: :already_installed, ansible_guard: :already_installed}} ===
+               QaDeployStepInstaller.install(path)
+
+      assert File.read!(path) === first_run
+    end
+
+    test "inserts QA step but reports no ansible guard when no ansible.deploy step", %{
+      tmp_dir: tmp_dir
+    } do
+      path = copy_fixture("no_ansible_deploy.yml", tmp_dir)
+
+      assert {:ok, %{qa_step: :inserted, ansible_guard: :not_applicable}} ===
+               QaDeployStepInstaller.install(path)
+
+      contents = File.read!(path)
+      assert contents =~ "# deploy_ex:qa-deploy:begin"
+      refute contents =~ "# deploy_ex:qa-skip"
+    end
+
+    test "skips ansible guard when step has a user-managed `if:` without marker", %{
+      tmp_dir: tmp_dir
+    } do
+      path = copy_fixture("user_managed_if.yml", tmp_dir)
+
+      assert {:ok, %{qa_step: :inserted, ansible_guard: :skipped_user_managed}} ===
+               QaDeployStepInstaller.install(path)
+
+      contents = File.read!(path)
+      assert contents =~ "# deploy_ex:qa-deploy:begin"
+      assert contents =~ "github.actor != 'dependabot[bot]'"
+      refute contents =~ "# deploy_ex:qa-skip"
+    end
+
+    test "returns :unprocessable_entity when no deploy_ex.upload anchor present", %{
+      tmp_dir: tmp_dir
+    } do
+      path = copy_fixture("no_anchor.yml", tmp_dir)
+      original = File.read!(path)
+
+      assert {:error, %ErrorMessage{code: :unprocessable_entity, message: msg}} =
+               QaDeployStepInstaller.install(path)
+
+      assert msg =~ "deploy_ex.upload"
+      assert File.read!(path) === original
+    end
+
+    test "returns :not_found when workflow file does not exist" do
+      missing = "/tmp/definitely_missing_#{System.unique_integer([:positive])}.yml"
+
+      assert {:error, %ErrorMessage{code: :not_found}} =
+               QaDeployStepInstaller.install(missing)
+    end
+  end
+
+  describe "installed?/1" do
+    test "true when both sentinels present", %{tmp_dir: tmp_dir} do
+      path = copy_fixture("fresh.yml", tmp_dir)
+      {:ok, _} = QaDeployStepInstaller.install(path)
+
+      assert QaDeployStepInstaller.installed?(path)
+    end
+
+    test "false on a fresh workflow", %{tmp_dir: tmp_dir} do
+      path = copy_fixture("fresh.yml", tmp_dir)
+      refute QaDeployStepInstaller.installed?(path)
+    end
+
+    test "false on a missing file" do
+      missing = "/tmp/missing_#{System.unique_integer([:positive])}.yml"
+      refute QaDeployStepInstaller.installed?(missing)
+    end
+  end
+
+  defp copy_fixture(name, tmp_dir) do
+    src = Path.join(@fixtures_root, name)
+    dest = Path.join(tmp_dir, name)
+    File.cp!(src, dest)
+    dest
+  end
+end

--- a/test/deploy_ex/qa_node_test.exs
+++ b/test/deploy_ex/qa_node_test.exs
@@ -469,4 +469,38 @@ defmodule DeployEx.QaNodeTest do
       assert label =~ "my_app"
     end
   end
+
+  describe "select_by_branch/2" do
+    test "returns the single matching node" do
+      a = %QaNode{instance_id: "i-aaa", git_branch: "qa/cfx_web-canary"}
+      b = %QaNode{instance_id: "i-bbb", git_branch: "qa/cfx_web-other"}
+
+      assert {:ok, %QaNode{instance_id: "i-aaa"}} =
+               QaNode.select_by_branch([a, b], "qa/cfx_web-canary")
+    end
+
+    test "returns :not_found when no node matches" do
+      a = %QaNode{instance_id: "i-aaa", git_branch: "qa/cfx_web-canary"}
+
+      assert {:error, %ErrorMessage{code: :not_found, message: msg}} =
+               QaNode.select_by_branch([a], "qa/cfx_web-other")
+
+      assert msg =~ "qa/cfx_web-other"
+    end
+
+    test "returns :conflict when multiple nodes share the branch" do
+      a = %QaNode{instance_id: "i-aaa", git_branch: "qa/cfx_web-canary"}
+      b = %QaNode{instance_id: "i-bbb", git_branch: "qa/cfx_web-canary"}
+
+      assert {:error, %ErrorMessage{code: :conflict, details: details}} =
+               QaNode.select_by_branch([a, b], "qa/cfx_web-canary")
+
+      assert details.instance_ids === ["i-aaa", "i-bbb"]
+    end
+
+    test "returns :not_found for empty node list" do
+      assert {:error, %ErrorMessage{code: :not_found}} =
+               QaNode.select_by_branch([], "qa/cfx_web-canary")
+    end
+  end
 end

--- a/test/support/fixtures/workflows/installer/fresh.yml
+++ b/test/support/fixtures/workflows/installer/fresh.yml
@@ -1,0 +1,35 @@
+name: Apply Terraform, Build & Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ApplyAndrelease:
+    name: Apply Terraform Changes and Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rebar & Hex
+        run: mix local.hex --force --if-missing && mix local.rebar --force --if-missing
+
+      - name: Build Releases
+        run: mix deploy_ex.release
+
+      - name: Upload S3 Releases
+        run: |
+          branch_name="${GITHUB_REF#refs/heads/}"
+          if [[ "$branch_name" == qa/* || "$branch_name" == qa-* ]]; then
+            mix deploy_ex.upload -l --qa
+          else
+            mix deploy_ex.upload -l
+          fi
+
+      - name: Run Ansible Deploy
+        run: mix ansible.deploy -l --target-sha $(git rev-parse --short ${{ github.sha }})
+
+      - name: Deauthorize AWS SSH
+        run: mix deploy_ex.ssh.authorize -r

--- a/test/support/fixtures/workflows/installer/no_anchor.yml
+++ b/test/support/fixtures/workflows/installer/no_anchor.yml
@@ -1,0 +1,16 @@
+name: No Upload Step
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Releases
+        run: mix deploy_ex.release
+      - name: Done
+        run: echo "done"

--- a/test/support/fixtures/workflows/installer/no_ansible_deploy.yml
+++ b/test/support/fixtures/workflows/installer/no_ansible_deploy.yml
@@ -1,0 +1,18 @@
+name: Upload Only
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Releases
+        run: mix deploy_ex.release
+
+      - name: Upload S3 Releases
+        run: mix deploy_ex.upload -l

--- a/test/support/fixtures/workflows/installer/user_managed_if.yml
+++ b/test/support/fixtures/workflows/installer/user_managed_if.yml
@@ -1,0 +1,20 @@
+name: User-Managed If
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Upload S3 Releases
+        run: mix deploy_ex.upload -l
+
+      - name: Run Ansible Deploy
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        run: mix ansible.deploy -l --target-sha $(git rev-parse --short ${{ github.sha }})


### PR DESCRIPTION
## Summary
- **`DeployEx.GitHubActions.QaDeployStepInstaller`** (new): idempotent text-level patcher that injects a `Deploy to QA Node` step after the `mix deploy_ex.upload` anchor and adds an `if:` guard on the existing `mix ansible.deploy` step so it skips on `qa/*` / `qa-*` refs. Sentinel comments (`# deploy_ex:qa-deploy:begin/end`, `# deploy_ex:qa-skip`) make re-runs no-ops; user-managed `if:` clauses on the ansible step are detected and left alone.
- **`mix deploy_ex.qa.create --wait-for-build`** now patches the detected workflow yml and commits it alongside the SSL/host rewrites, so the same GitHub Actions run that produces the QA release also deploys it. `--skip-action-install` opts out.
- **`mix deploy_ex.qa.deploy --git-branch <branch>`** (new flag): non-interactive node selection by `git_branch`. Powered by a new `DeployEx.QaNode.select_by_branch/2` helper that returns `:not_found` when no node matches and `:conflict` when more than one share the branch.
- Wizard registry updated for both new switches.

## Test plan
- [x] `mix test test/deploy_ex/github_actions/` — 9 installer tests (fresh insert, idempotent, no-ansible step, user-managed-if skip, missing-anchor error, missing-file error, `installed?/1` true/false/missing).
- [x] `mix test test/deploy_ex/qa_node_test.exs` — 4 new `select_by_branch/2` tests (single match, not_found, conflict on duplicates, empty list).
- [x] `mix test test/deploy_ex/tui/wizard/command_registry_test.exs` — wizard parity passes for `qa.create` + `qa.deploy` (pre-existing `ansible.setup` drift is unrelated).
- [x] `mix compile --warnings-as-errors --force` clean.
- [ ] Manual: run `mix deploy_ex.qa.create cfx_web --wait-for-build --tag canary` against a real repo; verify the workflow yml gets patched, committed, and the build's `Deploy to QA Node` step lands the release on the QA node.
- [ ] Manual: re-run the same command; verify installer reports `already_installed` and the yml is untouched.