### PR TITLE
feat(tool_installer): consent prompt + terraform/ansible auto-gating

### DIFF
--- a/lib/deploy_ex/terraform.ex
+++ b/lib/deploy_ex/terraform.ex
@@ -54,24 +54,30 @@ defmodule DeployEx.Terraform do
   end
 
   def run_command(command, terraform_directory) do
-    DeployEx.Utils.run_command_with_return(
-      "#{DeployEx.Config.iac_tool()} #{command}",
-      terraform_directory
-    )
+    with :ok <- DeployEx.ToolInstaller.ensure_installed(:terraform) do
+      DeployEx.Utils.run_command_with_return(
+        "#{DeployEx.Config.iac_tool()} #{command}",
+        terraform_directory
+      )
+    end
   end
 
   def run_command_with_input(command, terraform_directory) do
-    DeployEx.Utils.run_command_with_input(
-      "#{DeployEx.Config.iac_tool()} #{command}",
-      terraform_directory
-    )
+    with :ok <- DeployEx.ToolInstaller.ensure_installed(:terraform) do
+      DeployEx.Utils.run_command_with_input(
+        "#{DeployEx.Config.iac_tool()} #{command}",
+        terraform_directory
+      )
+    end
   end
 
   def run_command_with_console_log(command, terraform_directory) do
-    DeployEx.Utils.run_command(
-      "#{DeployEx.Config.iac_tool()} #{command}",
-      terraform_directory
-    )
+    with :ok <- DeployEx.ToolInstaller.ensure_installed(:terraform) do
+      DeployEx.Utils.run_command(
+        "#{DeployEx.Config.iac_tool()} #{command}",
+        terraform_directory
+      )
+    end
   end
 
   def find_pem_file(terraform_directory, pem_file) when is_nil(pem_file) do

--- a/lib/deploy_ex/tool_installer.ex
+++ b/lib/deploy_ex/tool_installer.ex
@@ -33,15 +33,31 @@ defmodule DeployEx.ToolInstaller do
     end
   end
 
-  @spec ensure_installed(:terraform | :ansible) :: :ok | {:error, ErrorMessage.t()}
-  def ensure_installed(:terraform) do
+  @doc """
+  Ensures the given tool is installed on the host, prompting the user for
+  consent before running the install command.
+
+  ## Options
+
+    * `:consent_fn` - 2-arity function `fn tool, info -> boolean end`. Defaults
+      to an interactive prompt via `Mix.shell().yes?/1`. The `info` map has
+      `:platform` and `:command` keys. Override for testing or for callers
+      that want to inject their own approval flow.
+
+  Consent prompting is skipped (treated as approved) when the
+  `DEPLOY_EX_AUTO_INSTALL` env var is set to `"true"`.
+  """
+  @spec ensure_installed(:terraform | :ansible | :gh, Keyword.t()) :: :ok | {:error, ErrorMessage.t()}
+  def ensure_installed(tool, opts \\ [])
+
+  def ensure_installed(:terraform, opts) do
     iac_tool = DeployEx.Config.iac_tool()
 
     case System.find_executable(iac_tool) do
       nil ->
         case iac_tool do
-          "terraform" -> install_tool(:terraform)
-          "tofu" -> install_tool(:tofu)
+          "terraform" -> install_tool(:terraform, opts)
+          "tofu" -> install_tool(:tofu, opts)
           other -> {:error, ErrorMessage.bad_request("#{__MODULE__}: unsupported iac_tool #{inspect(other)}, expected \"terraform\" or \"tofu\"")}
         end
 
@@ -49,16 +65,16 @@ defmodule DeployEx.ToolInstaller do
     end
   end
 
-  def ensure_installed(:ansible) do
+  def ensure_installed(:ansible, opts) do
     case System.find_executable("ansible-playbook") do
-      nil -> install_tool(:ansible)
+      nil -> install_tool(:ansible, opts)
       _path -> :ok
     end
   end
 
-  def ensure_installed(:gh) do
+  def ensure_installed(:gh, opts) do
     case System.find_executable("gh") do
-      nil -> install_tool(:gh)
+      nil -> install_tool(:gh, opts)
       _path -> :ok
     end
   end
@@ -163,7 +179,9 @@ defmodule DeployEx.ToolInstaller do
 
   def install_command(:gh, :amazon_linux), do: {"sudo dnf install -y gh", "."}
 
-  defp install_tool(tool) do
+  @doc false
+  @spec install_tool(:terraform | :tofu | :ansible | :gh, Keyword.t()) :: :ok | {:error, ErrorMessage.t()}
+  def install_tool(tool, opts \\ []) do
     platform = detect_platform()
 
     case install_command(tool, platform) do
@@ -171,19 +189,49 @@ defmodule DeployEx.ToolInstaller do
         error
 
       {command, directory} ->
-        Mix.shell().info([:yellow, "#{tool} not found, installing for #{platform}..."])
+        consent_fn = Keyword.get(opts, :consent_fn, &default_consent?/2)
 
-        case DeployEx.Utils.run_command_with_return(command, directory) do
-          {:ok, _output} ->
-            Mix.shell().info([:green, "#{tool} installed successfully"])
-            :ok
-
-          {:error, error} ->
-            {:error, ErrorMessage.internal_server_error(
-              "#{__MODULE__}: failed to install #{tool}, error: #{inspect(error)}"
-            )}
+        if consent_fn.(tool, %{platform: platform, command: command}) do
+          run_install_command(tool, command, directory)
+        else
+          {:error, ErrorMessage.bad_request(
+            "#{__MODULE__}: #{tool} install declined by user, install it manually then retry"
+          )}
         end
     end
+  end
+
+  defp run_install_command(tool, command, directory) do
+    Mix.shell().info([:yellow, "Installing #{tool}..."])
+
+    case DeployEx.Utils.run_command_with_return(command, directory) do
+      {:ok, _output} ->
+        Mix.shell().info([:green, "#{tool} installed successfully"])
+        :ok
+
+      {:error, error} ->
+        {:error, ErrorMessage.internal_server_error(
+          "#{__MODULE__}: failed to install #{tool}, error: #{inspect(error)}"
+        )}
+    end
+  end
+
+  @doc false
+  @spec default_consent?(atom(), %{platform: atom(), command: String.t()}) :: boolean()
+  def default_consent?(tool, %{platform: platform, command: command}) do
+    if auto_install?() do
+      true
+    else
+      Mix.shell().info([:yellow, "\n#{tool} is not installed."])
+      Mix.shell().info([:reset, "Detected platform: ", :bright, to_string(platform)])
+      Mix.shell().info([:reset, "Install command: ", :bright, command])
+      Mix.shell().yes?("Install #{tool} now?")
+    end
+  end
+
+  @doc false
+  def auto_install? do
+    System.get_env("DEPLOY_EX_AUTO_INSTALL") === "true"
   end
 
   defp detect_linux_distro do

--- a/lib/mix/tasks/ansible.ping.ex
+++ b/lib/mix/tasks/ansible.ping.ex
@@ -20,7 +20,8 @@ defmodule Mix.Tasks.Ansible.Ping do
   def run(args) do
     ansible_args = DeployEx.Ansible.parse_args(args)
 
-    with :ok <- DeployExHelpers.check_valid_project() do
+    with :ok <- DeployExHelpers.check_valid_project(),
+         :ok <- DeployEx.ToolInstaller.ensure_installed(:ansible) do
       DeployExHelpers.check_file_exists!("./deploys/ansible/aws_ec2.yaml")
 
       DeployEx.Utils.run_command(

--- a/test/deploy_ex/tool_installer_test.exs
+++ b/test/deploy_ex/tool_installer_test.exs
@@ -1,5 +1,7 @@
+# credo:disable-for-this-file BlitzCredoChecks.NoAsyncFalse
 defmodule DeployEx.ToolInstallerTest do
-  use ExUnit.Case, async: true
+  # async: false — tests mutate global Mix.shell + System env vars
+  use ExUnit.Case, async: false
 
   alias DeployEx.ToolInstaller
 
@@ -72,7 +74,7 @@ defmodule DeployEx.ToolInstallerTest do
     end
   end
 
-  describe "ensure_installed/1" do
+  describe "ensure_installed/2" do
     test "returns :ok when terraform is already installed" do
       iac_tool = DeployEx.Config.iac_tool()
 
@@ -90,7 +92,126 @@ defmodule DeployEx.ToolInstallerTest do
         assert :ok === ToolInstaller.ensure_installed(:ansible)
       end
     end
+
+    test "returns declined error when consent_fn returns false and binary is missing" do
+      if is_nil(System.find_executable("ansible-playbook")) do
+        consent_fn = fn _tool, _info -> false end
+
+        assert {:error, %ErrorMessage{code: :bad_request, message: msg}} =
+                 ToolInstaller.ensure_installed(:ansible, consent_fn: consent_fn)
+
+        assert msg =~ "declined by user"
+      else
+        :ok
+      end
+    end
+
+    test "passes platform + command to consent_fn" do
+      received = self()
+      consent_fn = fn tool, info ->
+        send(received, {:consent_called, tool, info})
+        false
+      end
+
+      _result = ToolInstaller.install_tool(:ansible, consent_fn: consent_fn)
+
+      assert_received {:consent_called, :ansible, %{platform: _platform, command: command}}
+      assert is_binary(command)
+      assert command =~ "ansible"
+    end
   end
+
+  describe "install_tool/2 consent contract" do
+    test "returns declined error when consent_fn returns false" do
+      consent_fn = fn _tool, _info -> false end
+
+      assert {:error, %ErrorMessage{code: :bad_request, message: msg}} =
+               ToolInstaller.install_tool(:ansible, consent_fn: consent_fn)
+
+      assert msg =~ "declined by user"
+    end
+
+  end
+
+  describe "default_consent?/2" do
+    test "returns true when DEPLOY_EX_AUTO_INSTALL=true" do
+      previous = System.get_env("DEPLOY_EX_AUTO_INSTALL")
+      System.put_env("DEPLOY_EX_AUTO_INSTALL", "true")
+
+      assert ToolInstaller.default_consent?(:ansible, %{platform: :macos, command: "brew install ansible"})
+
+      restore_env("DEPLOY_EX_AUTO_INSTALL", previous)
+    end
+
+    test "delegates to Mix.shell yes? prompt when env not set" do
+      previous = System.get_env("DEPLOY_EX_AUTO_INSTALL")
+      System.delete_env("DEPLOY_EX_AUTO_INSTALL")
+
+      original_shell = Mix.shell()
+      Mix.shell(Mix.Shell.Process)
+
+      send(self(), {:mix_shell_input, :yes?, true})
+
+      result = ToolInstaller.default_consent?(:ansible, %{platform: :macos, command: "brew install ansible"})
+
+      assert result
+      assert_received {:mix_shell, :info, [_lines]}
+      assert_received {:mix_shell, :info, [_platform_line]}
+      assert_received {:mix_shell, :info, [_command_line]}
+      assert_received {:mix_shell, :yes?, [prompt]}
+      assert prompt =~ "Install ansible"
+
+      Mix.shell(original_shell)
+      restore_env("DEPLOY_EX_AUTO_INSTALL", previous)
+    end
+
+    test "returns false when user declines at the prompt" do
+      previous = System.get_env("DEPLOY_EX_AUTO_INSTALL")
+      System.delete_env("DEPLOY_EX_AUTO_INSTALL")
+
+      original_shell = Mix.shell()
+      Mix.shell(Mix.Shell.Process)
+
+      send(self(), {:mix_shell_input, :yes?, false})
+
+      refute ToolInstaller.default_consent?(:ansible, %{platform: :macos, command: "brew install ansible"})
+
+      Mix.shell(original_shell)
+      restore_env("DEPLOY_EX_AUTO_INSTALL", previous)
+    end
+  end
+
+  describe "auto_install?/0" do
+    test "returns true when env var is exactly \"true\"" do
+      previous = System.get_env("DEPLOY_EX_AUTO_INSTALL")
+      System.put_env("DEPLOY_EX_AUTO_INSTALL", "true")
+
+      assert ToolInstaller.auto_install?()
+
+      restore_env("DEPLOY_EX_AUTO_INSTALL", previous)
+    end
+
+    test "returns false when env var is unset" do
+      previous = System.get_env("DEPLOY_EX_AUTO_INSTALL")
+      System.delete_env("DEPLOY_EX_AUTO_INSTALL")
+
+      refute ToolInstaller.auto_install?()
+
+      restore_env("DEPLOY_EX_AUTO_INSTALL", previous)
+    end
+
+    test "returns false when env var is some other value" do
+      previous = System.get_env("DEPLOY_EX_AUTO_INSTALL")
+      System.put_env("DEPLOY_EX_AUTO_INSTALL", "yes")
+
+      refute ToolInstaller.auto_install?()
+
+      restore_env("DEPLOY_EX_AUTO_INSTALL", previous)
+    end
+  end
+
+  defp restore_env(key, nil), do: System.delete_env(key)
+  defp restore_env(key, value), do: System.put_env(key, value)
 
   describe "install_command/2" do
     test "returns brew command for terraform on macos" do


### PR DESCRIPTION
## Summary

- Ansible/terraform commands now refuse to run until the binary is installed, and ask the user before installing it.
- Single chokepoint at `DeployEx.Terraform.run_command*` — all 11 terraform Mix tasks inherit the gate.
- `mix ansible.ping` was the only ansible task without the gate; now gated.
- `DEPLOY_EX_AUTO_INSTALL=true` skips the prompt for CI / non-interactive use.

## What changed

| File | Change |
|---|---|
| `lib/deploy_ex/tool_installer.ex` | `ensure_installed/2` accepts `:consent_fn` opt. `install_tool/2` exposed (`@doc false`) for testability. New `default_consent?/2` prints platform + command, prompts via `Mix.shell().yes?/1`. `auto_install?/0` reads `DEPLOY_EX_AUTO_INSTALL`. |
| `lib/deploy_ex/terraform.ex` | `run_command`, `run_command_with_input`, `run_command_with_console_log` each wrap in `with :ok <- ToolInstaller.ensure_installed(:terraform)`. |
| `lib/mix/tasks/ansible.ping.ex` | Adds `:ok <- ToolInstaller.ensure_installed(:ansible)` to the with-chain. |
| `test/deploy_ex/tool_installer_test.exs` | Tests for consent contract (declined → error), env-var bypass, Mix.shell prompt path with `Mix.Shell.Process` capture. |

## Prompt UX

When ansible / terraform / tofu / gh is missing:

```
ansible is not installed.
Detected platform: macos
Install command: brew install ansible
Install ansible now? [Yn]
```

If the user says no, `ensure_installed/2` returns `{:error, %ErrorMessage{code: :bad_request, message: "...declined by user, install it manually then retry"}}` and the Mix task exits without running the binary.

If `DEPLOY_EX_AUTO_INSTALL=true` is set, the prompt is skipped and the install command runs unattended.

## OS coverage (unchanged from existing module)

macOS (brew), Debian/Ubuntu (apt + pip3 for ansible), Alpine (apk), Amazon Linux (yum/dnf). Windows returns an error pointing at WSL.

## Test plan

- [x] `mix test test/deploy_ex/tool_installer_test.exs` — 31/31 pass
- [x] `mix compile --warnings-as-errors`
- [x] Full suite: 357/366 pass; 9 pre-existing failures in `AwsInfrastructureTest` + `CommandRegistryTest` are unchanged on baseline (confirmed via stash diff) — not caused by this PR
- [x] Verified pipe-into-case + boolean-literal style violations were caught and removed