### PR TITLE
fix(terraform/cloud-init): wait for cloud-init.target before app start

### DIFF
--- a/priv/terraform/modules/aws-instance/cloud_init_data.yaml.tftpl
+++ b/priv/terraform/modules/aws-instance/cloud_init_data.yaml.tftpl
@@ -124,7 +124,7 @@ write_files:
       cat > /etc/systemd/system/$${APP_NAME}.service <<EOF
       [Unit]
       Description=$${APP_NAME} service
-      After=network.target
+      After=network.target cloud-init.target
 
       [Service]
       Type=simple


### PR DESCRIPTION
## Summary

- Add `cloud-init.target` to the systemd unit's `After=` ordering in `priv/terraform/modules/aws-instance/cloud_init_data.yaml.tftpl` so app service waits for cloud-init's release swap before starting.

## Why

New ASG instances launched from an AMI start the AMI-baked release via systemd ~30s before cloud-init runs `deploy-app.sh` (which downloads latest release from S3, stops the service, swaps, restarts). During that ~30s window the BEAM is live on OLD code.

Downstream consumer (Cheddar-Flow) hit this 2026-05-27: cfx_web ASG rotated. New instance booted from an AMI baked at an older SHA. systemd auto-started cfx_web from `/srv/cfx_web/` before cloud-init swapped to the latest release. During the gap, the BEAM built `%SharedFeedUtils.Feed{}` structs via the OLD defstruct (missing a field that was added after the AMI snapshot) and RPCed to a peer service running new code. Receiver's pattern required the missing key → `function_clause` → caller retry loop → ~20 min of broken pages across the ASG roll.

`save_ami` runs `cloud-init clean --logs` before snapshot so cloud-init re-runs on new instances, but it does NOT stop the app service or wipe `/srv/<app>/` — so AMIs always carry the previously-installed release forward, and systemd auto-starts it on first boot before cloud-init can swap.

## Fix

`After=network.target cloud-init.target` blocks the service from starting until cloud-init.target is reached (after `cloud-final.service` completes). Once cloud-init has done its stop+swap+start, the new code is what runs.

## Caveat — needs one AMI rebake

The unit file is created by cloud-init at deploy time, so this change takes full effect only after an AMI is rebaked from an instance that ran cloud-init with the updated template. Until rebake, the FIRST boot from existing AMIs uses the OLD unit (no `cloud-init.target` ordering) and still has the window. Subsequent boots from rebaked AMI = ordering enforced from systemd init.

Mirror PR going up against the Cheddar-Flow cheddar_flow_ex_umbrella to update its vendored copy of the template (Cheddar-Flow/cheddar_flow_ex_umbrella#1014).

## Test plan

- [ ] No behavior change to `mix deploy_ex.*` tasks
- [ ] terraform plan from a consumer repo shows only the user_data tftpl content changes
- [ ] After deploy + AMI rebake, force-roll one instance and confirm in journal that `<app>.service` Active state transitions to `active` AFTER cloud-init `Deployment complete!` line, not before