### PR TITLE
feat(ansible): forward --tags/--skip-tags to ansible-playbook

### DIFF
--- a/lib/deploy_ex/ansible.ex
+++ b/lib/deploy_ex/ansible.ex
@@ -2,13 +2,15 @@ defmodule DeployEx.Ansible do
   @ansible_flags [
     inventory: :string,
     limit: :string,
-    extra_vars: :keep
+    extra_vars: :keep,
+    tags: :string,
+    skip_tags: :string
   ]
 
   def parse_args(args) do
     {ansible_opts, _extra_args, _invalid_args} =
       OptionParser.parse(args,
-        aliases: [i: :inventory, e: :extra_vars],
+        aliases: [i: :inventory, e: :extra_vars, t: :tags],
         strict: @ansible_flags
       )
 

--- a/test/deploy_ex/ansible_test.exs
+++ b/test/deploy_ex/ansible_test.exs
@@ -1,0 +1,29 @@
+defmodule DeployEx.AnsibleTest do
+  use ExUnit.Case, async: true
+
+  alias DeployEx.Ansible
+
+  describe "parse_args/1" do
+    test "forwards --tags" do
+      assert "--tags thetadata_terminal" === Ansible.parse_args(["--tags", "thetadata_terminal"])
+    end
+
+    test "forwards -t alias as --tags" do
+      assert "--tags thetadata_terminal" === Ansible.parse_args(["-t", "thetadata_terminal"])
+    end
+
+    test "forwards --skip-tags" do
+      assert "--skip-tags save_ami" === Ansible.parse_args(["--skip-tags", "save_ami"])
+    end
+
+    test "forwards --limit alongside --tags" do
+      assert "--limit i-0abc* --tags thetadata_terminal" ===
+               Ansible.parse_args(["--limit", "i-0abc*", "--tags", "thetadata_terminal"])
+    end
+
+    test "drops unknown flags" do
+      assert "--tags thetadata_terminal" ===
+               Ansible.parse_args(["--unknown", "x", "--tags", "thetadata_terminal"])
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `--tags` and `--skip-tags` (with `-t` alias) passthrough in `DeployEx.Ansible.parse_args/1`.

## Why

`@ansible_flags` strict-whitelisted only `inventory`/`limit`/`extra_vars`, so unknown flags were dropped — `mix ansible.setup`/`ansible.deploy` could not scope a run to specific roles. Now:

```
mix ansible.setup --only my_app --tags some_role
mix ansible.deploy --only my_app --skip-tags save_ami
```

## Tests

New `test/deploy_ex/ansible_test.exs` covers `--tags`, `-t`, `--skip-tags`, combination with `--limit`, and that unknown flags are still dropped. 5 tests, 0 failures.