### PR TITLE
fix(qa_node): launch QA nodes with resource-name DNS

### DIFF
--- a/lib/deploy_ex/qa_node.ex
+++ b/lib/deploy_ex/qa_node.ex
@@ -83,6 +83,13 @@ defmodule DeployEx.QaNode do
       {"NetworkInterface.1.SubnetId", params[:subnet_id]},
       {"NetworkInterface.1.SecurityGroupId.1", params[:security_group_id]},
       {"NetworkInterface.1.AssociatePublicIpAddress", "true"},
+      # Match the Terraform-provisioned nodes (resource-name DNS): the BEAM
+      # cluster addresses nodes by their bare instance-id node name, which only
+      # resolves when the instance publishes an <instance-id>.<region>.compute
+      # A record. The QA subnet defaults to ip-name, so without this QA nodes
+      # are unreachable as RPC targets (libcluster cannot connect to them).
+      {"PrivateDnsNameOptions.HostnameType", "resource-name"},
+      {"PrivateDnsNameOptions.EnableResourceNameDnsARecord", "true"},
       {"UserData", Base.encode64(user_data)},
       iam_instance_profile: [name: params[:iam_instance_profile]],
       tag_specifications: [{:instance, tags}]


### PR DESCRIPTION
## Problem

QA nodes are created via `QaNode.create_instance` → `ExAws.EC2.run_instances`, whose `run_opts` set the subnet, SG, and public IP but **omit `PrivateDnsNameOptions`**. They therefore inherit the subnet's default `PrivateDnsHostnameTypeOnLaunch` (`ip-name`).

The Terraform-provisioned (prod) nodes set:
```hcl
private_dns_name_options {
  hostname_type                     = "resource-name"
  enable_resource_name_dns_a_record = true
}
```

The BEAM cluster addresses nodes by their bare instance-id node name (`app@i-xxxx`). That only resolves when the instance publishes an `<instance-id>.<region>.compute` A record (resource-name DNS). With `ip-name`, a QA node is **unreachable as an RPC target** — libcluster on other nodes cannot connect to it. Observed: a QA `theta_data_service` node sat isolated (`peers=[]`) and cross-node `RpcLoadBalancer` calls failed with "no nodes in cluster found with that filter".

## Fix

Set the same two options on the run-instances call so QA nodes match the Terraform-provisioned nodes:
```
PrivateDnsNameOptions.HostnameType            = resource-name
PrivateDnsNameOptions.EnableResourceNameDnsARecord = true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)