### PR TITLE
fix(cloud-init): start app non-blocking to break cloud-init.target boot deadlock

### DIFF
--- a/priv/terraform/modules/aws-instance/cloud_init_data.yaml.tftpl
+++ b/priv/terraform/modules/aws-instance/cloud_init_data.yaml.tftpl
@@ -124,7 +124,7 @@ write_files:
       cat > /etc/systemd/system/$${APP_NAME}.service <<EOF
       [Unit]
       Description=$${APP_NAME} service
-      After=network.target
+      After=network.target cloud-init.target
 
       [Service]
       Type=simple

--- a/priv/terraform/modules/aws-instance/cloud_init_data.yaml.tftpl
+++ b/priv/terraform/modules/aws-instance/cloud_init_data.yaml.tftpl
@@ -144,11 +144,25 @@ write_files:
       WantedBy=multi-user.target
       EOF
 
-      # Enable and start service
-      echo "Starting $${APP_NAME} service..."
+      # Enable the unit, then start it NON-BLOCKING.
+      #
+      # The unit is ordered `After=cloud-init.target` (see the [Unit] block
+      # above) so a fresh boot does not auto-start the AMI-baked release before
+      # this script swaps in the correct one. But this script runs inside
+      # cloud-final.service, and cloud-init.target only activates once
+      # cloud-final finishes. A blocking `systemctl start` here waits on a start
+      # job that is itself ordered after cloud-init.target, so cloud-final can
+      # never finish: deadlock until the systemd job times out. The app then
+      # misses the ASG ELB health grace and the instance is replaced in a loop
+      # (each replacement re-issues a Let's Encrypt cert -> rate-limit lockout).
+      #
+      # --no-block enqueues the start and returns immediately: cloud-final
+      # completes, cloud-init.target activates, and the queued job launches the
+      # freshly-swapped release. Do NOT remove --no-block.
+      echo "Enabling $${APP_NAME} service (start deferred to cloud-init.target)..."
       systemctl daemon-reload
       systemctl enable $${APP_NAME}
-      systemctl start $${APP_NAME}
+      systemctl start --no-block $${APP_NAME}
 
       echo "Deployment complete!"
       systemctl status $${APP_NAME} --no-pager || true


### PR DESCRIPTION
## Problem

The app systemd unit is ordered `After=network.target cloud-init.target` so a fresh ASG boot does not auto-start the AMI-baked release before cloud-init swaps in the correct one (the fix for the stale-`defstruct` cross-node RPC `function_clause` race).

But `deploy-app.sh` runs **inside `cloud-final.service`** and ends with a **blocking** `systemctl start`. That start job is ordered after `cloud-init.target`, which only activates once `cloud-final` finishes — which is blocked on the start. Circular wait:

```
systemctl start (in cloud-final)  ->  waits on app start job
app start job                     ->  ordered After=cloud-init.target
cloud-init.target                 ->  waits for cloud-final.service
cloud-final.service               ->  blocked on systemctl start
```

The start blocks until the systemd job times out; the app misses the ASG's 60s ELB health grace and the instance is replaced. On repeat, each replacement boots a fresh instance whose ephemeral SiteEncrypt `db_folder` (`/tmp/cfx-encrypt`) is empty, so it re-issues from Let's Encrypt and trips the **5-cert/168h** limit (`429 acme:error:rateLimited`).

## Production impact (2026-07-10)

A 03:18 UTC `terraform apply` baked this ordering into new launch templates (**cfx-web v13, cfx-hooks-web v12**). At market open both ASGs entered a ~2-minute ELB-health replacement loop (19 distinct `cfx_hooks_web` instances in 40 min); `cfx_hooks_web` exhausted the Let's Encrypt rate limit and stopped serving. Mitigated live by pinning the ASGs back to the prior launch-template versions (hooks v11).

## Fix

Keep the `cloud-init.target` ordering — it is the correct stale-code guard — but change the in-script start to `systemctl start --no-block`. The start is enqueued and returns immediately, so `cloud-final` completes, `cloud-init.target` activates, and the queued job launches the freshly swapped release. No deadlock, no early stale-code window. Inline comment added so the flag is not removed later.

## Rollout note

Requires one AMI rebake / new launch-template version to ship the corrected unit script; boots from the rebaked AMI use the non-blocking start on first boot. Do not re-apply the pre-fix template to the ASGs.