### PR TITLE
QA nodes boot with a _qa release sname suffix

### DIFF
--- a/lib/deploy_ex/qa_node.ex
+++ b/lib/deploy_ex/qa_node.ex
@@ -596,7 +596,8 @@ defmodule DeployEx.QaNode do
     |> String.replace(~r/[^a-z0-9-]/, "")
   end
 
-  defp build_qa_user_data(app_name, target_sha, environment) do
+  @doc false
+  def build_qa_user_data(app_name, target_sha, environment) do
     bucket_name = "#{app_name}-elixir-deploys-#{environment}"
 
     """
@@ -666,6 +667,12 @@ defmodule DeployEx.QaNode do
     rm -rf /srv/$APP_NAME
     mv /srv/unpack-directory /srv/$APP_NAME
     chmod -R 755 /srv/$APP_NAME
+
+    # Mark this node as a QA node to the BEAM release so it joins the cluster
+    # under a distinct sname (options_feed_qa@host instead of options_feed@host).
+    # This keeps it structurally excluded from prod node filters.
+    mkdir -p /etc/systemd/system/$APP_NAME.service.d
+    printf '[Service]\nEnvironment=RELEASE_NODE_SUFFIX=_qa\n' > /etc/systemd/system/$APP_NAME.service.d/qa-node-suffix.conf
 
     # Start service
     echo "Starting $APP_NAME service..."

--- a/priv/ansible/aws_ec2.yaml.eex
+++ b/priv/ansible/aws_ec2.yaml.eex
@@ -29,6 +29,7 @@ compose:
   letsencrypt_use_public_ip: (tags['UsePublicIpCert'] | default('false')) == 'true'
   release_prefix: "'qa' if (tags['QaNode'] | default('false')) == 'true' else ''"
   release_state_prefix: "'release-state/qa' if (tags['QaNode'] | default('false')) == 'true' else 'release-state'"
+  qa_node_suffix: "'_qa' if (tags['QaNode'] | default('false')) == 'true' else ''"
   git_branch: tags['GitBranch'] | default('')
   instance_tag: tags['InstanceTag'] | default('')
 

--- a/priv/ansible/roles/deploy_node/defaults/main.yaml
+++ b/priv/ansible/roles/deploy_node/defaults/main.yaml
@@ -3,6 +3,7 @@ bucket_name: "{{ deploy_s3_bucket }}"
 target_release_sha: ""
 release_prefix: ""
 release_state_prefix: "release-state"
+qa_node_suffix: ""
 app_port: 80
 extra_env: []
 system_env: []

--- a/priv/ansible/roles/deploy_node/templates/erlang_systemd.service.j2
+++ b/priv/ansible/roles/deploy_node/templates/erlang_systemd.service.j2
@@ -12,6 +12,7 @@ ExecStop=/srv/{{ app_name }}/bin/{{ app_name }} stop
 Restart=on-failure
 RestartSec=5
 Environment=PORT={{ app_port }}
+Environment="RELEASE_NODE_SUFFIX={{ qa_node_suffix }}"
 {% for env in extra_env %}
 Environment={{ env }}
 {% endfor %}

--- a/test/deploy_ex/qa_node_test.exs
+++ b/test/deploy_ex/qa_node_test.exs
@@ -580,6 +580,27 @@ defmodule DeployEx.QaNodeTest do
     end
   end
 
+  describe "build_qa_user_data/3" do
+    test "writes a systemd drop-in that suffixes the BEAM release node with _qa" do
+      user_data = QaNode.build_qa_user_data("options_feed", "abc1234", "prod")
+
+      assert user_data =~ "mkdir -p /etc/systemd/system/$APP_NAME.service.d"
+      assert user_data =~ "Environment=RELEASE_NODE_SUFFIX=_qa"
+      assert user_data =~ "/etc/systemd/system/$APP_NAME.service.d/qa-node-suffix.conf"
+    end
+
+    test "writes the drop-in before the service is (re)started" do
+      user_data = QaNode.build_qa_user_data("options_feed", "abc1234", "prod")
+
+      drop_in_index = :binary.match(user_data, "qa-node-suffix.conf") |> elem(0)
+      daemon_reload_index = :binary.match(user_data, "systemctl daemon-reload") |> elem(0)
+      start_index = :binary.match(user_data, "systemctl start $APP_NAME") |> elem(0)
+
+      assert drop_in_index < daemon_reload_index
+      assert drop_in_index < start_index
+    end
+  end
+
   describe "ansible_limit_pattern/1" do
     test "returns an instance-id glob safe for ansible --limit even when the Name tag has whitespace" do
       qa_node = %QaNode{


### PR DESCRIPTION
## Motivation

QA EC2 nodes (`mix deploy_ex.qa.create`) boot Elixir releases with the same sname prod uses (`RELEASE_NODE=<release.name>`, `RELEASE_DISTRIBUTION=sname` in the umbrella's `rel/env.sh.eex`). That makes a QA node indistinguishable from a prod node once it joins libcluster, so prod RPC routing (`CFXRpc.route_to_node("options_feed", ...)`) can land prod feed traffic on QA branch code.

The umbrella already ships anchored node-filter matching (`SharedUtils.Cluster.node_matches_filter?/2`) which structurally excludes `_qa`-suffixed node names from prod filters — this PR is the deploy_ex half: actually give QA nodes that suffix at boot.

This is a companion to the umbrella-side change in `cheddar_flow_ex_umbrella#<TBD>` (`rel/env.sh.eex` reads `RELEASE_NODE_SUFFIX`).

## Changes

QA nodes are launched through two independent boot paths — both needed the fix:

1. **Ansible `deploy_node` role** (`ansible.setup`/`ansible.deploy`/regular QA node provisioning): `priv/ansible/aws_ec2.yaml.eex` now composes a `qa_node_suffix` fact from the `QaNode` EC2 tag, mirroring the existing `release_prefix`/`release_state_prefix` pattern. The role's `defaults/main.yaml` gets a matching `qa_node_suffix: ""` fallback, and `erlang_systemd.service.j2` renders it as `Environment="RELEASE_NODE_SUFFIX={{ qa_node_suffix }}"`.
2. **QA-node cloud-init** (`DeployEx.QaNode.build_qa_user_data/3`): this path is ad-hoc — it reuses the systemd unit already baked into the AMI rather than templating a fresh one, so the ansible fact above never reaches it. It now drops a systemd override file (`/etc/systemd/system/$APP_NAME.service.d/qa-node-suffix.conf`) setting `RELEASE_NODE_SUFFIX=_qa` before the service is (re)started.

Checked `mix deploy_ex.qa.modify` (resize / EBS grow / Elastic IP / cert) and the other QA task modules — none of them rewrite the systemd unit or re-run user-data, so the drop-in from initial boot persists across those operations unmodified.

## Testing

- `mix test` — all passing except 6 pre-existing failures in `test/deploy_ex/aws_infrastructure_test.exs` unrelated to this change (confirmed failing identically on `main`).
- Added `build_qa_user_data/3` tests asserting the drop-in is written, contains the `_qa` suffix, and lands before `systemctl daemon-reload`/`start`.
- `mix compile --warnings-as-errors` clean. (No `mix credo` config in this repo.)