### PR TITLE
feat(oci): adapt k6 load testing to the Cloud seam (OCI machine + live verify)

### DIFF
--- a/.claude/skills/deploy-ex-oci/SKILL.md
+++ b/.claude/skills/deploy-ex-oci/SKILL.md
@@ -16,7 +16,7 @@ OCI is the second provider behind the `DeployEx.Cloud` seam. Everything OCI goes
 | `inventory` | Static — `ansible.build` queries the oci CLI, renders `oci.yaml` snapshot |
 | `machine` | `DeployEx.Cloud.OciMachine` — run/terminate/describe/list instances, `await_running`, via the `oci` CLI (compartment-scoped) |
 | `infrastructure` | `DeployEx.Cloud.OciInfrastructure` — config-driven subnet/image/key material for the loadtest path |
-| `cli_adapter` | `DeployEx.Cloud.OciCli` — shared shell runner (session-token auth aware, shell-quoted args) |
+| `cli_adapter` | `nil` — the OCI modules call `DeployEx.Cloud.OciCli` directly; the descriptor slot is unfilled |
 
 Verified live: `terraform.build/init/plan --provider oci`, `ansible.build`, `ansible.ping`, `ansible.setup`, `deploy_ex.upload`. Roughly 26 mix tasks remain AWS-only (`ssh`, `instance.*`, `restart_app`, `find_nodes`, `qa.*`, `autoscale.*`, load balancer, EBS snapshots, DB dump/restore) — check `capabilities/0` in `lib/deploy_ex/cloud/providers/oci.ex` before promising a task works on OCI.
 
@@ -24,8 +24,8 @@ Verified live: `terraform.build/init/plan --provider oci`, `ansible.build`, `ans
 
 | Task | Under `--provider oci` |
 |------|------|
-| `create_instance` / `destroy_instance` | Wired through `OciMachine` (launch/terminate in the configured compartment; `await_running` lifecycle gate). Live-verified in S3. |
-| `exec` | Runner resolution via `OciMachine.describe_instance`; prometheus discovery is AWS-only (warns + runs without metrics export under `:oci`) |
+| `create_instance` / `destroy_instance` | Wired through `OciMachine` (launch/terminate in the configured compartment; `await_running` lifecycle gate). Live verification lands with LT-OCI S3. |
+| `exec` | Runner resolution via `OciMachine.describe_instance`; prometheus discovery IS provider-routed (issues an OCI instance-list) but no OCI prometheus node exists to find — it warns and runs without metrics export |
 | `upload` | Runner resolution via `OciMachine`; scp/ssh use the descriptor's `default_ssh_user` (`ubuntu`) |
 | `list` | State-op paths (`fetch_all_runners`) route through `object_store` and work once `:oci` `release_bucket` is configured; the EC2-fallback path (`find_runners_from_ec2`) errors `:not_implemented` under any non-AWS provider by design — it must never print AWS's leftover runners as OCI's |
 | `init` | Provider-agnostic (writes local files only) |
@@ -46,7 +46,7 @@ config :deploy_ex,
   ]
 ```
 
-The `:oci` namespace is validated strictly (NimbleOptions) — a typo'd key fails at task start. All keys optional, but `release_bucket` and `resource_group` are read eagerly (not lazily defaulted like their AWS flat-key equivalents) by anything going through `Cloud.release_bucket/1` / `Cloud.resource_group/1` — e.g. `deploy_ex.load_test.*`'s state ops — and left unset they error loudly (`{:error, %ErrorMessage{code: :bad_request}}`) rather than silently sending an empty container/tag name to the `oci` CLI. Read via `Config.oci_setting(key)` (a thin wrapper over the generic `Config.provider_setting(:oci, key)`); task opts carry an `oci_` prefix (`--oci-region`) so a bare AWS `:region` can never leak in as the OCI region. Full key list: `@config_schema` in `lib/deploy_ex/cloud/providers/oci.ex`. The loadtest machine path additionally REQUIRES: `compartment_id`, `availability_domain`, `subnet_id`, `base_image`, `shape`, `ssh_public_key` — each errors `bad_request` naming the key when unset.
+The `:oci` namespace is validated strictly (NimbleOptions) — a typo'd key fails at task start. All keys optional, but `release_bucket` and `resource_group` are read eagerly (not lazily defaulted like their AWS flat-key equivalents) by anything going through `Cloud.release_bucket/1` / `Cloud.resource_group/1` — e.g. `deploy_ex.load_test.*`'s state ops — and left unset they error loudly (`{:error, %ErrorMessage{code: :bad_request}}`) rather than silently sending an empty container/tag name to the `oci` CLI. Read via `Config.oci_setting(key)` (a thin wrapper over the generic `Config.provider_setting(:oci, key)`); task opts carry an `oci_` prefix (`--oci-region`) so a bare AWS `:region` can never leak in as the OCI region. Full key list: `@config_schema` in `lib/deploy_ex/cloud/providers/oci.ex`. The loadtest machine path additionally REQUIRES: `compartment_id`, `availability_domain`, `subnet_id`, `base_image`, `ssh_public_key` (key CONTENTS, not a path) — each errors `bad_request` naming the key when unset. `shape` is optional (defaults to `VM.Standard.E5.Flex`).
 
 ## Auth
 

--- a/.claude/skills/deploy-ex-oci/SKILL.md
+++ b/.claude/skills/deploy-ex-oci/SKILL.md
@@ -14,7 +14,9 @@ OCI is the second provider behind the `DeployEx.Cloud` seam. Everything OCI goes
 | `object_store` (`Cloud.OciObjectStore`) | Filled — releases/state via oci CLI |
 | `security` (`Cloud.OciSecurityGroup`) | Filled |
 | `inventory` | Static — `ansible.build` queries the oci CLI, renders `oci.yaml` snapshot |
-| `machine` / `infrastructure` / `cli_adapter` | `nil` — returns `{:error, :not_implemented}` |
+| `machine` | `DeployEx.Cloud.OciMachine` — run/terminate/describe/list instances, `await_running`, via the `oci` CLI (compartment-scoped) |
+| `infrastructure` | `DeployEx.Cloud.OciInfrastructure` — config-driven subnet/image/key material for the loadtest path |
+| `cli_adapter` | `DeployEx.Cloud.OciCli` — shared shell runner (session-token auth aware, shell-quoted args) |
 
 Verified live: `terraform.build/init/plan --provider oci`, `ansible.build`, `ansible.ping`, `ansible.setup`, `deploy_ex.upload`. Roughly 26 mix tasks remain AWS-only (`ssh`, `instance.*`, `restart_app`, `find_nodes`, `qa.*`, `autoscale.*`, load balancer, EBS snapshots, DB dump/restore) — check `capabilities/0` in `lib/deploy_ex/cloud/providers/oci.ex` before promising a task works on OCI.
 
@@ -22,9 +24,9 @@ Verified live: `terraform.build/init/plan --provider oci`, `ansible.build`, `ans
 
 | Task | Under `--provider oci` |
 |------|------|
-| `create_instance` / `destroy_instance` | `{:error, :not_implemented}` — `machine` capability not wired (S2) |
-| `exec` | `{:error, :not_implemented}` — same, resolving the runner needs `machine` |
-| `upload` | Same — resolving the runner needs `machine` |
+| `create_instance` / `destroy_instance` | Wired through `OciMachine` (launch/terminate in the configured compartment; `await_running` lifecycle gate). Live-verified in S3. |
+| `exec` | Runner resolution via `OciMachine.describe_instance`; prometheus discovery is AWS-only (warns + runs without metrics export under `:oci`) |
+| `upload` | Runner resolution via `OciMachine`; scp/ssh use the descriptor's `default_ssh_user` (`ubuntu`) |
 | `list` | State-op paths (`fetch_all_runners`) route through `object_store` and work once `:oci` `release_bucket` is configured; the EC2-fallback path (`find_runners_from_ec2`) errors `:not_implemented` under any non-AWS provider by design — it must never print AWS's leftover runners as OCI's |
 | `init` | Provider-agnostic (writes local files only) |
 
@@ -44,7 +46,7 @@ config :deploy_ex,
   ]
 ```
 
-The `:oci` namespace is validated strictly (NimbleOptions) — a typo'd key fails at task start. All keys optional, but `release_bucket` and `resource_group` are read eagerly (not lazily defaulted like their AWS flat-key equivalents) by anything going through `Cloud.release_bucket/1` / `Cloud.resource_group/1` — e.g. `deploy_ex.load_test.*`'s state ops — and left unset they error loudly (`{:error, %ErrorMessage{code: :bad_request}}`) rather than silently sending an empty container/tag name to the `oci` CLI. Read via `Config.oci_setting(key)` (a thin wrapper over the generic `Config.provider_setting(:oci, key)`); task opts carry an `oci_` prefix (`--oci-region`) so a bare AWS `:region` can never leak in as the OCI region. Full key list: `@config_schema` in `lib/deploy_ex/cloud/providers/oci.ex`.
+The `:oci` namespace is validated strictly (NimbleOptions) — a typo'd key fails at task start. All keys optional, but `release_bucket` and `resource_group` are read eagerly (not lazily defaulted like their AWS flat-key equivalents) by anything going through `Cloud.release_bucket/1` / `Cloud.resource_group/1` — e.g. `deploy_ex.load_test.*`'s state ops — and left unset they error loudly (`{:error, %ErrorMessage{code: :bad_request}}`) rather than silently sending an empty container/tag name to the `oci` CLI. Read via `Config.oci_setting(key)` (a thin wrapper over the generic `Config.provider_setting(:oci, key)`); task opts carry an `oci_` prefix (`--oci-region`) so a bare AWS `:region` can never leak in as the OCI region. Full key list: `@config_schema` in `lib/deploy_ex/cloud/providers/oci.ex`. The loadtest machine path additionally REQUIRES: `compartment_id`, `availability_domain`, `subnet_id`, `base_image`, `shape`, `ssh_public_key` — each errors `bad_request` naming the key when unset.
 
 ## Auth
 

--- a/.claude/skills/deploy-ex-oci/SKILL.md
+++ b/.claude/skills/deploy-ex-oci/SKILL.md
@@ -18,6 +18,16 @@ OCI is the second provider behind the `DeployEx.Cloud` seam. Everything OCI goes
 
 Verified live: `terraform.build/init/plan --provider oci`, `ansible.build`, `ansible.ping`, `ansible.setup`, `deploy_ex.upload`. Roughly 26 mix tasks remain AWS-only (`ssh`, `instance.*`, `restart_app`, `find_nodes`, `qa.*`, `autoscale.*`, load balancer, EBS snapshots, DB dump/restore) — check `capabilities/0` in `lib/deploy_ex/cloud/providers/oci.ex` before promising a task works on OCI.
 
+`deploy_ex.load_test.*` (all accept `--provider oci`, validated — an unrecognized value raises rather than silently running against AWS):
+
+| Task | Under `--provider oci` |
+|------|------|
+| `create_instance` / `destroy_instance` | `{:error, :not_implemented}` — `machine` capability not wired (S2) |
+| `exec` | `{:error, :not_implemented}` — same, resolving the runner needs `machine` |
+| `upload` | Same — resolving the runner needs `machine` |
+| `list` | State-op paths (`fetch_all_runners`) route through `object_store` and work once `:oci` `release_bucket` is configured; the EC2-fallback path (`find_runners_from_ec2`) errors `:not_implemented` under any non-AWS provider by design — it must never print AWS's leftover runners as OCI's |
+| `init` | Provider-agnostic (writes local files only) |
+
 ## Configuration
 
 ```elixir
@@ -29,11 +39,12 @@ config :deploy_ex,
     compartment_id: "ocid1.compartment...",
     namespace: "...",
     release_bucket: "...",
+    resource_group: "...",
     profile: "DEFAULT"
   ]
 ```
 
-The `:oci` namespace is validated strictly (NimbleOptions) — a typo'd key fails at task start. All keys optional. Read via `Config.oci_setting(key)`; task opts carry an `oci_` prefix (`--oci-region`) so a bare AWS `:region` can never leak in as the OCI region. Full key list: `@config_schema` in `lib/deploy_ex/cloud/providers/oci.ex`.
+The `:oci` namespace is validated strictly (NimbleOptions) — a typo'd key fails at task start. All keys optional, but `release_bucket` and `resource_group` are read eagerly (not lazily defaulted like their AWS flat-key equivalents) by anything going through `Cloud.release_bucket/1` / `Cloud.resource_group/1` — e.g. `deploy_ex.load_test.*`'s state ops — and left unset they error loudly (`{:error, %ErrorMessage{code: :bad_request}}`) rather than silently sending an empty container/tag name to the `oci` CLI. Read via `Config.oci_setting(key)` (a thin wrapper over the generic `Config.provider_setting(:oci, key)`); task opts carry an `oci_` prefix (`--oci-region`) so a bare AWS `:region` can never leak in as the OCI region. Full key list: `@config_schema` in `lib/deploy_ex/cloud/providers/oci.ex`.
 
 ## Auth
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,3 +17,12 @@ if System.get_env("CI") in ["true", true] do
     user: "root",
     limit_users: ["root"]
 end
+
+# Real (non-nil) :oci namespace value so tests can assert on a literal instead of comparing a
+# provider-config accessor against its own read of the same key — a nil===nil comparison would
+# stay green whether the accessor reads the right namespace or nothing at all. :release_bucket
+# is deliberately left UNSET here — DeployEx.CloudTest's "unset config" tests need a real,
+# registered provider whose value is genuinely nil to prove the loud-error path.
+if config_env() === :test do
+  config :deploy_ex, :oci, resource_group: "OCI Test Backend"
+end

--- a/guides/how-to/load_testing.md
+++ b/guides/how-to/load_testing.md
@@ -2,7 +2,7 @@
 
 deploy_ex provides built-in k6 load testing infrastructure using ephemeral runner instances. Test results push to Prometheus via remote-write and visualise in Grafana.
 
-Runner **state** (save/fetch/list/delete) is provider-routed through `DeployEx.Cloud`'s object-store capability, so it works against either provider's configured bucket. Runner **lifecycle** (create/terminate/list-from-cloud) is AWS-only today — the `--provider` flag is accepted by every `load_test.*` task and validated, but passing `--provider oci` currently surfaces `:not_implemented` for create/destroy/exec/upload (OCI's machine capability isn't wired yet).
+Runner **state** (save/fetch/list/delete) is provider-routed through `DeployEx.Cloud`'s object-store capability, so it works against either provider's configured bucket. Runner **lifecycle** (create/terminate/describe/list) is provider-routed too: under `--provider oci` instances launch via the `oci` CLI into the configured compartment (requires the `:oci` config keys `compartment_id`, `availability_domain`, `subnet_id`, `base_image`, `shape`, `ssh_public_key`). Prometheus discovery remains AWS-only — under `:oci` the exec warns and runs without metrics export.
 
 ## Quick Start
 

--- a/guides/how-to/load_testing.md
+++ b/guides/how-to/load_testing.md
@@ -1,6 +1,8 @@
 # How to Run Load Tests
 
-deploy_ex provides built-in k6 load testing infrastructure using ephemeral EC2 runner instances. Test results push to Prometheus via remote-write and visualise in Grafana.
+deploy_ex provides built-in k6 load testing infrastructure using ephemeral runner instances. Test results push to Prometheus via remote-write and visualise in Grafana.
+
+Runner **state** (save/fetch/list/delete) is provider-routed through `DeployEx.Cloud`'s object-store capability, so it works against either provider's configured bucket. Runner **lifecycle** (create/terminate/list-from-cloud) is AWS-only today — the `--provider` flag is accepted by every `load_test.*` task and validated, but passing `--provider oci` currently surfaces `:not_implemented` for create/destroy/exec/upload (OCI's machine capability isn't wired yet).
 
 ## Quick Start
 
@@ -32,7 +34,7 @@ The template also sets `thresholds.http_req_failed` with `abortOnFail: true`, so
 
 ## Runner Management
 
-Runners are standalone EC2 instances with k6 pre-installed via cloud-init. State is stored in S3 at `k6-runners/{instance_id}.json`. The create command checks for existing runners before launching new ones, so calling it repeatedly is safe — whether reusing or freshly creating a runner, it isn't reported ready until SSH is reachable and `k6 version` succeeds on the instance. If a found runner fails that check, recreate it with `--force`.
+Runners are standalone compute instances with k6 pre-installed via cloud-init — today provisioned on AWS EC2 only. Runner state is stored via the active provider's object store at `k6-runners/{instance_id}.json` (AWS: S3; a correctly-configured OCI object store would work the same way once machine provisioning lands). The create command checks for existing runners before launching new ones, so calling it repeatedly is safe — whether reusing or freshly creating a runner, it isn't reported ready until SSH is reachable and `k6 version` succeeds on the instance. If a found runner fails that check, recreate it with `--force`.
 
 ```bash
 mix deploy_ex.load_test.create_instance --instance-type t3.medium    # default is t3.small

--- a/guides/how-to/load_testing.md
+++ b/guides/how-to/load_testing.md
@@ -2,7 +2,7 @@
 
 deploy_ex provides built-in k6 load testing infrastructure using ephemeral runner instances. Test results push to Prometheus via remote-write and visualise in Grafana.
 
-Runner **state** (save/fetch/list/delete) is provider-routed through `DeployEx.Cloud`'s object-store capability, so it works against either provider's configured bucket. Runner **lifecycle** (create/terminate/describe/list) is provider-routed too: under `--provider oci` instances launch via the `oci` CLI into the configured compartment (requires the `:oci` config keys `compartment_id`, `availability_domain`, `subnet_id`, `base_image`, `shape`, `ssh_public_key`). Prometheus discovery remains AWS-only — under `:oci` the exec warns and runs without metrics export.
+Runner **state** (save/fetch/list/delete) is provider-routed through `DeployEx.Cloud`'s object-store capability, so it works against either provider's configured bucket. Runner **lifecycle** (create/terminate/describe/list) is provider-routed too: under `--provider oci` instances launch via the `oci` CLI into the configured compartment (requires the `:oci` config keys `compartment_id`, `availability_domain`, `subnet_id`, `base_image`, `ssh_public_key` — the key CONTENTS, not a path; `shape` optional with a default). Prometheus discovery remains AWS-only — under `:oci` the exec warns and runs without metrics export.
 
 ## Quick Start
 

--- a/guides/reference/mix_tasks.md
+++ b/guides/reference/mix_tasks.md
@@ -232,11 +232,13 @@ Overview / quick start (no flags).
 |------|----------|
 | `mix deploy_ex.load_test` | (overview, no flags) |
 | `mix deploy_ex.load_test.init` | (scaffolds k6 scripts under `./load_tests/`) |
-| `mix deploy_ex.load_test.create_instance` | `--instance-type`, `--resource-group`, `--pem`, `-f force`, `-q quiet` |
-| `mix deploy_ex.load_test.destroy_instance` | `-i instance-id`, `--all`, `-f force`, `-q quiet` |
-| `mix deploy_ex.load_test.list` | `--json`, `-q quiet` |
-| `mix deploy_ex.load_test.upload` | `-i instance-id`, `--script <path>`, `--pem`, `-q quiet` |
-| `mix deploy_ex.load_test.exec` | `-i instance-id`, `--script <path>`, `--target-url`, `--prometheus-url`, `--pem`, `-q quiet` |
+| `mix deploy_ex.load_test.create_instance` | `--instance-type`, `--resource-group`, `--pem`, `--provider`, `-f force`, `-q quiet` |
+| `mix deploy_ex.load_test.destroy_instance` | `-i instance-id`, `--all`, `--provider`, `-f force`, `-q quiet` |
+| `mix deploy_ex.load_test.list` | `--json`, `--provider`, `-q quiet` |
+| `mix deploy_ex.load_test.upload` | `-i instance-id`, `--script <path>`, `--pem`, `--provider`, `-q quiet` |
+| `mix deploy_ex.load_test.exec` | `-i instance-id`, `--script <path>`, `--target-url`, `--prometheus-url`, `--pem`, `--provider`, `-q quiet` |
+
+`--provider` (`aws` or `oci`) overrides the configured `cloud_provider`; an unrecognized value raises rather than being silently ignored. Machine ops (`create_instance`/`destroy_instance`/`exec`/`upload`) are AWS-only until OCI's `machine` capability lands — see `deploy-ex-oci` skill for the current per-task status under `--provider oci`.
 
 ## Monitoring
 

--- a/guides/reference/mix_tasks.md
+++ b/guides/reference/mix_tasks.md
@@ -238,7 +238,7 @@ Overview / quick start (no flags).
 | `mix deploy_ex.load_test.upload` | `-i instance-id`, `--script <path>`, `--pem`, `--provider`, `-q quiet` |
 | `mix deploy_ex.load_test.exec` | `-i instance-id`, `--script <path>`, `--target-url`, `--prometheus-url`, `--pem`, `--provider`, `-q quiet` |
 
-`--provider` (`aws` or `oci`) overrides the configured `cloud_provider`; an unrecognized value raises rather than being silently ignored. Machine ops (`create_instance`/`destroy_instance`/`exec`/`upload`) are AWS-only until OCI's `machine` capability lands — see `deploy-ex-oci` skill for the current per-task status under `--provider oci`.
+`--provider` (`aws` or `oci`) overrides the configured `cloud_provider`; an unrecognized value raises rather than being silently ignored. Machine ops (`create_instance`/`destroy_instance`/`exec`/`upload`) work on both providers — see the `deploy-ex-oci` skill for the required `:oci` config keys and per-task notes under `--provider oci`.
 
 ## Monitoring
 

--- a/lib/deploy_ex/aws_infrastructure.ex
+++ b/lib/deploy_ex/aws_infrastructure.ex
@@ -320,6 +320,7 @@ defmodule DeployEx.AwsInfrastructure do
     {:ok, latest["imageId"]}
   end
 
+  @impl DeployEx.Cloud.Infrastructure
   def gather_infrastructure(opts \\ []) do
     with {:ok, security_group} <- DeployEx.AwsSecurityGroup.find_security_group(opts),
          {:ok, subnet_ids} <- find_subnet_ids(Keyword.put(opts, :vpc_id, security_group.vpc_id)),

--- a/lib/deploy_ex/aws_machine.ex
+++ b/lib/deploy_ex/aws_machine.ex
@@ -103,9 +103,11 @@ defmodule DeployEx.AwsMachine do
     |> handle_run_instance_response()
   end
 
+  @default_instance_type "t3.small"
+
   defp run_instance_params(spec) do
     [
-      {"InstanceType", spec.instance_type},
+      {"InstanceType", spec.instance_type || @default_instance_type},
       {"KeyName", spec.network[:key_name]},
       {"NetworkInterface.1.DeviceIndex", "0"},
       {"NetworkInterface.1.SubnetId", spec.network[:subnet_id]},

--- a/lib/deploy_ex/aws_machine.ex
+++ b/lib/deploy_ex/aws_machine.ex
@@ -78,6 +78,97 @@ defmodule DeployEx.AwsMachine do
     end
   end
 
+  @doc """
+  Translates a provider-neutral run-instance spec into EC2 `RunInstances` params.
+
+  Implements the optional `DeployEx.Cloud.Machine.run_instance/2` callback so
+  `DeployEx.K6Runner.create_instance/2` can build one spec and let each provider's adapter
+  translate it, instead of assembling EC2-shaped params itself.
+  """
+  @impl DeployEx.Cloud.Machine
+  def run_instance(spec, opts \\ []) do
+    region = opts[:region] || DeployEx.Config.aws_region()
+    request_fn = opts[:request_fn] || (&ExAws.request/2)
+
+    spec.network[:ami_id]
+    |> ExAws.EC2.run_instances(1, 1, run_instance_params(spec))
+    |> request_fn.(region: region)
+    |> handle_run_instance_response()
+  end
+
+  defp run_instance_params(spec) do
+    [
+      {"InstanceType", spec.instance_type},
+      {"KeyName", spec.network[:key_name]},
+      {"NetworkInterface.1.DeviceIndex", "0"},
+      {"NetworkInterface.1.SubnetId", spec.network[:subnet_id]},
+      {"NetworkInterface.1.SecurityGroupId.1", spec.network[:security_group_id]},
+      {"NetworkInterface.1.AssociatePublicIpAddress", "true"},
+      {"UserData", Base.encode64(spec.user_data)},
+      iam_instance_profile: [name: spec.network[:iam_instance_profile]],
+      tag_specifications: [{:instance, spec.tags}]
+    ]
+  end
+
+  defp handle_run_instance_response({:ok, %{body: body}}) do
+    case XmlToMap.naive_map(body) do
+      %{"RunInstancesResponse" => %{"instancesSet" => %{"item" => %{"instanceId" => instance_id}}}} ->
+        {:ok, %DeployEx.Cloud.Instance{id: instance_id}}
+
+      %{"RunInstancesResponse" => %{"instancesSet" => %{"item" => [%{"instanceId" => instance_id} | _]}}} ->
+        {:ok, %DeployEx.Cloud.Instance{id: instance_id}}
+
+      structure ->
+        {:error, ErrorMessage.bad_request(
+          "couldn't parse run instances response from aws",
+          %{structure: structure}
+        )}
+    end
+  end
+
+  defp handle_run_instance_response({:error, {:http_error, status_code, %{body: body}}}) do
+    {:error, apply(ErrorMessage, ErrorMessage.http_code_reason_atom(status_code), [
+      "error creating instance",
+      %{error_body: body}
+    ])}
+  end
+
+  @doc "Implements the optional `DeployEx.Cloud.Machine.terminate_instance/2` callback."
+  @impl DeployEx.Cloud.Machine
+  def terminate_instance(instance_id, opts \\ []) do
+    region = opts[:region] || DeployEx.Config.aws_region()
+    request_fn = opts[:request_fn] || (&ExAws.request/2)
+
+    [instance_id]
+    |> ExAws.EC2.terminate_instances()
+    |> request_fn.(region: region)
+    |> handle_terminate_instance_response()
+  end
+
+  defp handle_terminate_instance_response({:ok, _}), do: :ok
+
+  defp handle_terminate_instance_response({:error, {:http_error, status_code, %{body: body}}}) do
+    {:error, apply(ErrorMessage, ErrorMessage.http_code_reason_atom(status_code), [
+      "error terminating instance",
+      %{error_body: body}
+    ])}
+  end
+
+  @doc """
+  Blocks until every instance id reports running. Implements the optional
+  `DeployEx.Cloud.Machine.await_running/2` callback by wrapping `wait_for_started/3` rather
+  than reimplementing its poll loop — `:wait_for_started_fn` is the injection seam that makes
+  the wrapping relationship (not the poll loop itself) testable.
+  """
+  @impl DeployEx.Cloud.Machine
+  def await_running(instance_ids, opts \\ []) do
+    region = opts[:region] || DeployEx.Config.aws_region()
+    retries = opts[:retries] || 10
+    wait_fn = opts[:wait_for_started_fn] || (&wait_for_started/3)
+
+    wait_fn.(region, instance_ids, retries)
+  end
+
   defp scoped_running_instances(opts) do
     region = opts[:region] || DeployEx.Config.aws_region()
     resource_group = opts[:resource_group] || DeployEx.Config.aws_resource_group()

--- a/lib/deploy_ex/aws_machine.ex
+++ b/lib/deploy_ex/aws_machine.ex
@@ -38,7 +38,14 @@ defmodule DeployEx.AwsMachine do
   def describe_instance(instance_id, opts \\ []) do
     region = opts[:region] || DeployEx.Config.aws_region()
 
-    with {:ok, [instance | _rest]} <- find_instances_by_id(region, [instance_id], opts) do
+    # Whitelisted, not forwarded whole: opts reaching this callback often carries a caller's
+    # full task opts (--pem path, :provider, :quiet, ...), and find_instances_by_id/3 passes
+    # anything beyond :request_fn straight into ExAws.EC2.describe_instances/1 as real API
+    # query params — an unfiltered forward would leak a pem file PATH to AWS and CloudTrail as
+    # "Pem" => "/secret/path/key.pem", and camelize every other stray key into a bogus filter.
+    ec2_opts = Keyword.take(opts, [:request_fn])
+
+    with {:ok, [instance | _rest]} <- find_instances_by_id(region, [instance_id], ec2_opts) do
       {:ok, to_instance(instance)}
     end
   end
@@ -559,7 +566,12 @@ defmodule DeployEx.AwsMachine do
     region = opts[:region] || DeployEx.Config.aws_region()
     all_filters = tag_filters ++ resource_group_filter(opts)
 
-    with {:ok, instances} <- fetch_instances(region) do
+    # Same G1 leak class as describe_instance/2: opts reaching here is often a caller's whole
+    # task opts (--pem path, :provider, :quiet, ...), and fetch_instances/2 forwards anything
+    # beyond :request_fn straight into ExAws.EC2.describe_instances/1 as real API query params.
+    ec2_opts = Keyword.take(opts, [:request_fn])
+
+    with {:ok, instances} <- fetch_instances(region, ec2_opts) do
       {:ok, filter_instances_by_tags(instances, all_filters)}
     end
   end

--- a/lib/deploy_ex/aws_machine.ex
+++ b/lib/deploy_ex/aws_machine.ex
@@ -170,7 +170,13 @@ defmodule DeployEx.AwsMachine do
   the wrapping relationship (not the poll loop itself) testable.
   """
   @impl DeployEx.Cloud.Machine
-  def await_running(instance_ids, opts \\ []) do
+  def await_running(instance_ids, opts \\ [])
+
+  def await_running([], _opts) do
+    {:error, ErrorMessage.bad_request("await_running requires at least one instance id")}
+  end
+
+  def await_running(instance_ids, opts) do
     region = opts[:region] || DeployEx.Config.aws_region()
     retries = opts[:retries] || 10
     wait_fn = opts[:wait_for_started_fn] || (&wait_for_started/3)

--- a/lib/deploy_ex/aws_machine.ex
+++ b/lib/deploy_ex/aws_machine.ex
@@ -38,7 +38,7 @@ defmodule DeployEx.AwsMachine do
   def describe_instance(instance_id, opts \\ []) do
     region = opts[:region] || DeployEx.Config.aws_region()
 
-    with {:ok, [instance | _rest]} <- find_instances_by_id(region, [instance_id]) do
+    with {:ok, [instance | _rest]} <- find_instances_by_id(region, [instance_id], opts) do
       {:ok, to_instance(instance)}
     end
   end
@@ -280,8 +280,8 @@ defmodule DeployEx.AwsMachine do
     instance["instanceState"]["name"] in ["pending", "running", "starting"]
   end
 
-  def find_instances_by_id(region \\ DeployEx.Config.aws_region(), instance_ids) do
-    with {:ok, instances} <- fetch_instances(region) do
+  def find_instances_by_id(region \\ DeployEx.Config.aws_region(), instance_ids, opts \\ []) do
+    with {:ok, instances} <- fetch_instances(region, opts) do
       case filter_by_instance_id(instances, instance_ids) do
         [] -> {:error, ErrorMessage.not_found("no aws instances found with those instance ids")}
         instances -> {:ok, instances}

--- a/lib/deploy_ex/cloud.ex
+++ b/lib/deploy_ex/cloud.ex
@@ -155,21 +155,34 @@ defmodule DeployEx.Cloud do
   @spec release_bucket(keyword()) :: {:ok, String.t()} | {:error, ErrorMessage.t()}
   def release_bucket(opts \\ []), do: provider_config_value(opts, :release_bucket, &Config.aws_release_bucket/0)
 
-  # Routes through fetch_descriptor/1 rather than switching on active_provider(opts) directly
-  # so a descriptor MODULE (the put_env-free test injection seam — same one capability/2 and
-  # validate_config/2 already accept) resolves through the same registry key as its atom form.
-  # Comparing the descriptor to DeployEx.Cloud.Providers.Aws (rather than the input atom to
-  # :aws) makes that true for AWS too, not only for non-AWS providers.
-  defp provider_config_value(opts, key, aws_reader) do
+  @doc """
+  Whether the active (or overridden) provider is AWS — the single shared answer to "is this
+  AWS", for any caller that needs to special-case the AWS path.
+
+  Routes through `fetch_descriptor/1` and compares the resolved DESCRIPTOR to
+  `DeployEx.Cloud.Providers.Aws`, rather than comparing the raw `active_provider(opts)` value
+  to the atom `:aws` — a caller passing the descriptor MODULE (the put_env-free test injection
+  seam `capability/2` and `validate_config/2` already accept) is AWS too, and a bare
+  `case active_provider(opts) do :aws -> ...` silently answers "no" for it. This exact gap has
+  recurred more than once (this module's own config accessors, then `K6Runner.find_runners_from_ec2/1`)
+  as separate ad-hoc `:aws` comparisons — one shared predicate instead of another one.
+  """
+  @spec aws?(keyword()) :: boolean()
+  def aws?(opts \\ []) do
     case opts |> active_provider() |> fetch_descriptor() do
-      {:ok, DeployEx.Cloud.Providers.Aws} ->
-        {:ok, aws_reader.()}
+      {:ok, DeployEx.Cloud.Providers.Aws} -> true
+      _not_aws_or_error -> false
+    end
+  end
 
-      {:ok, descriptor} ->
-        provider_setting_or_error(registry_key_for(descriptor), key)
-
-      {:error, _reason} = error ->
-        error
+  defp provider_config_value(opts, key, aws_reader) do
+    if aws?(opts) do
+      {:ok, aws_reader.()}
+    else
+      case opts |> active_provider() |> fetch_descriptor() do
+        {:ok, descriptor} -> provider_setting_or_error(registry_key_for(descriptor), key)
+        {:error, _reason} = error -> error
+      end
     end
   end
 

--- a/lib/deploy_ex/cloud.ex
+++ b/lib/deploy_ex/cloud.ex
@@ -101,6 +101,43 @@ defmodule DeployEx.Cloud do
   @spec providers() :: [atom()]
   def providers, do: Map.keys(@providers)
 
+  @doc """
+  SSH user for the active (or overridden) provider, resolved through its descriptor.
+
+  Falls back to `"admin"` when the descriptor cannot be resolved (unregistered provider) or
+  declares no default — the historical AWS default, so a lookup failure never blocks a task
+  that otherwise ran fine before this accessor existed.
+  """
+  @spec ssh_user(keyword()) :: String.t()
+  def ssh_user(opts \\ []) do
+    case opts |> active_provider() |> fetch_descriptor() do
+      {:ok, descriptor} -> descriptor.default_ssh_user() || "admin"
+      {:error, _reason} -> "admin"
+    end
+  end
+
+  @doc """
+  Resource group / project tag namespace for the active (or overridden) provider.
+
+  AWS reads its historical flat key; every other provider reads `:resource_group` from its
+  own config namespace (`config :deploy_ex, <provider>, resource_group: ...`), which
+  `validate_config/2` already validates against the descriptor's schema.
+  """
+  @spec resource_group(keyword()) :: String.t() | nil
+  def resource_group(opts \\ []), do: provider_config_value(opts, :resource_group, &Config.aws_resource_group/0)
+
+  @doc "Release bucket for the active (or overridden) provider, same resolution rule as `resource_group/1`."
+  @spec release_bucket(keyword()) :: String.t() | nil
+  def release_bucket(opts \\ []), do: provider_config_value(opts, :release_bucket, &Config.aws_release_bucket/0)
+
+  defp provider_config_value(opts, key, aws_reader) do
+    case active_provider(opts) do
+      :aws -> aws_reader.()
+      provider when is_atom(provider) -> Application.get_env(:deploy_ex, provider, [])[key]
+      _non_atom -> nil
+    end
+  end
+
   defp invalid_config_error(provider, env) do
     {:error,
      ErrorMessage.bad_request("#{inspect(provider)} config must be a keyword list", %{

--- a/lib/deploy_ex/cloud.ex
+++ b/lib/deploy_ex/cloud.ex
@@ -121,20 +121,52 @@ defmodule DeployEx.Cloud do
 
   AWS reads its historical flat key; every other provider reads `:resource_group` from its
   own config namespace (`config :deploy_ex, <provider>, resource_group: ...`), which
-  `validate_config/2` already validates against the descriptor's schema.
+  `validate_config/2` already validates against the descriptor's schema. Returns an error
+  rather than `nil` when a real provider has not configured the key — see `provider_config_value/3`.
   """
-  @spec resource_group(keyword()) :: String.t() | nil
+  @spec resource_group(keyword()) :: {:ok, String.t()} | {:error, ErrorMessage.t()}
   def resource_group(opts \\ []), do: provider_config_value(opts, :resource_group, &Config.aws_resource_group/0)
 
   @doc "Release bucket for the active (or overridden) provider, same resolution rule as `resource_group/1`."
-  @spec release_bucket(keyword()) :: String.t() | nil
+  @spec release_bucket(keyword()) :: {:ok, String.t()} | {:error, ErrorMessage.t()}
   def release_bucket(opts \\ []), do: provider_config_value(opts, :release_bucket, &Config.aws_release_bucket/0)
 
+  # Routes through fetch_descriptor/1 rather than switching on active_provider(opts) directly
+  # so a descriptor MODULE (the put_env-free test injection seam — same one capability/2 and
+  # validate_config/2 already accept) resolves through the same registry key as its atom form.
+  # Comparing the descriptor to DeployEx.Cloud.Providers.Aws (rather than the input atom to
+  # :aws) makes that true for AWS too, not only for non-AWS providers.
   defp provider_config_value(opts, key, aws_reader) do
-    case active_provider(opts) do
-      :aws -> aws_reader.()
-      provider when is_atom(provider) -> Application.get_env(:deploy_ex, provider, [])[key]
-      _non_atom -> nil
+    case opts |> active_provider() |> fetch_descriptor() do
+      {:ok, DeployEx.Cloud.Providers.Aws} ->
+        {:ok, aws_reader.()}
+
+      {:ok, descriptor} ->
+        provider_setting_or_error(registry_key_for(descriptor), key)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp registry_key_for(descriptor) do
+    Enum.find_value(@providers, descriptor, fn {registry_key, mod} -> if mod === descriptor, do: registry_key end)
+  end
+
+  # A silent nil here would reach an object-store/CLI call as an empty container name (e.g.
+  # OCI's `--bucket-name ''`) — fail loudly instead, matching OciObjectStore.require_compartment_id/1's
+  # precedent of erroring on a missing config value rather than sending a malformed request.
+  defp provider_setting_or_error(provider, key) do
+    case Config.provider_setting(provider, key) do
+      nil ->
+        {:error,
+         ErrorMessage.bad_request(
+           "#{key} is required for #{inspect(provider)} (config :deploy_ex, #{inspect(provider)}, #{key}: \"...\")",
+           %{provider: provider, key: key}
+         )}
+
+      value ->
+        {:ok, value}
     end
   end
 

--- a/lib/deploy_ex/cloud.ex
+++ b/lib/deploy_ex/cloud.ex
@@ -102,6 +102,30 @@ defmodule DeployEx.Cloud do
   def providers, do: Map.keys(@providers)
 
   @doc """
+  Parses a CLI `--provider` flag value into a registered provider atom.
+
+  Never `String.to_atom/1`s the input — an unrecognized value errors instead of interning a
+  fresh atom for every typo a caller makes. `nil` (the flag was not given) resolves to `nil`,
+  not an error, so callers can `opts[:provider] || Config.cloud_provider()` unchanged.
+  """
+  @spec parse_provider(String.t() | nil) :: {:ok, atom() | nil} | {:error, ErrorMessage.t()}
+  def parse_provider(nil), do: {:ok, nil}
+
+  def parse_provider(value) when is_binary(value) do
+    case Enum.find(providers(), &(Atom.to_string(&1) === value)) do
+      nil ->
+        {:error,
+         ErrorMessage.bad_request("unknown provider #{inspect(value)} — known providers: #{inspect(providers())}", %{
+           provider: value,
+           known_providers: providers()
+         })}
+
+      provider ->
+        {:ok, provider}
+    end
+  end
+
+  @doc """
   SSH user for the active (or overridden) provider, resolved through its descriptor.
 
   Falls back to `"admin"` when the descriptor cannot be resolved (unregistered provider) or

--- a/lib/deploy_ex/cloud/infrastructure.ex
+++ b/lib/deploy_ex/cloud/infrastructure.ex
@@ -18,4 +18,16 @@ defmodule DeployEx.Cloud.Infrastructure do
   @doc "Identity the instance assumes so it can read releases and write state markers."
   @callback find_instance_identity(keyword()) ::
               {:ok, String.t() | nil} | {:error, ErrorMessage.t()}
+
+  @doc """
+  Composite convenience gathering every value above (plus a security group where the provider
+  has one) in a single call, for callers that need the full set to launch an instance ad-hoc.
+
+  Optional: today only the AWS adapter implements it (`DeployEx.AwsInfrastructure.gather_infrastructure/1`,
+  a pre-existing public function this callback formalizes) — a provider without an
+  ad-hoc-launch caller conforms without it.
+  """
+  @callback gather_infrastructure(keyword()) :: {:ok, map()} | {:error, ErrorMessage.t()}
+
+  @optional_callbacks gather_infrastructure: 1
 end

--- a/lib/deploy_ex/cloud/machine.ex
+++ b/lib/deploy_ex/cloud/machine.ex
@@ -69,6 +69,16 @@ defmodule DeployEx.Cloud.Machine do
   @doc "Preferred reachable address for an instance. IPv6 wins when present."
   @callback instance_address(Instance.t()) :: {:ok, String.t()} | {:error, ErrorMessage.t()}
 
+  @doc """
+  Blocks until every given instance id reports as running, or returns an error.
+
+  Optional for the same reason as `run_instance/2`: only a provider whose lifecycle needs an
+  ad-hoc launch-and-wait (today, the load-test runner) implements it. The AWS implementation
+  wraps the pre-existing `DeployEx.AwsMachine.wait_for_started/3` rather than reimplementing
+  the poll loop.
+  """
+  @callback await_running([String.t()], keyword()) :: :ok | {:error, ErrorMessage.t()}
+
   @callback fetch_tags(String.t(), keyword()) ::
               {:ok, %{optional(String.t()) => String.t()}} | {:error, ErrorMessage.t()}
 
@@ -83,5 +93,9 @@ defmodule DeployEx.Cloud.Machine do
   # provider conforms today without them, and the Phase-5 train makes them required when it
   # moves those call sites behind this behaviour. Implementing them now would be unused code
   # with no test that could fail.
-  @optional_callbacks run_instance: 2, terminate_instance: 2, put_tags: 3, delete_tags: 3
+  @optional_callbacks run_instance: 2,
+                      terminate_instance: 2,
+                      put_tags: 3,
+                      delete_tags: 3,
+                      await_running: 2
 end

--- a/lib/deploy_ex/cloud/oci_cli.ex
+++ b/lib/deploy_ex/cloud/oci_cli.ex
@@ -61,18 +61,27 @@ defmodule DeployEx.Cloud.OciCli do
   # SUPPRESS_LABEL_WARNING silences a stderr nag about unlabeled API keys. That nag would
   # otherwise land in the merged stdout/stderr stream run_command_with_return/2 returns and
   # break JSON decoding.
+  #
+  # :auth/:profile/:region come from opts (an oci_* CLI override) or application config, both
+  # of which land here unvalidated for shell-safety — an unquoted value with a `;`, `&&`, or
+  # backtick is a shell injection, not just a malformed OCI flag. quote_arg/1 (below) wraps
+  # every one of them the same way OciMachine/OciObjectStore quote their own command args.
   defp build_command(subcommand, opts) do
     auth = setting(opts, :auth) || "api_key"
     flags = build_flags(opts)
 
-    String.trim("OCI_CLI_AUTH=#{auth} SUPPRESS_LABEL_WARNING=True oci #{subcommand} #{flags}")
+    String.trim("OCI_CLI_AUTH=#{quote_arg(auth)} SUPPRESS_LABEL_WARNING=True oci #{subcommand} #{flags}")
   end
 
   defp build_flags(opts) do
     [{"--profile", setting(opts, :profile)}, {"--region", setting(opts, :region)}]
     |> Enum.reject(fn {_flag, value} -> is_nil(value) end)
-    |> Enum.map_join(" ", fn {flag, value} -> "#{flag} #{value}" end)
+    |> Enum.map_join(" ", fn {flag, value} -> "#{flag} #{quote_arg(value)}" end)
   end
+
+  @doc "Single-quotes a shell argument, escaping embedded single quotes. Shared by every OCI CLI caller."
+  @spec quote_arg(term()) :: String.t()
+  def quote_arg(value), do: "'#{String.replace(to_string(value), "'", "'\\''")}'"
 
   defp decode_payload(output) do
     case String.trim(output) do

--- a/lib/deploy_ex/cloud/oci_infrastructure.ex
+++ b/lib/deploy_ex/cloud/oci_infrastructure.ex
@@ -25,6 +25,11 @@ defmodule DeployEx.Cloud.OciInfrastructure do
     require_setting(opts, :subnet_id)
   end
 
+  # CONTRACT ASYMMETRY, deliberate: AWS's find_key_pair returns a key-pair NAME (an EC2
+  # registry handle passed to RunInstances); OCI has no key-pair registry — the public key
+  # travels in launch metadata (ssh_authorized_keys) and what callers need locally is the
+  # PEM PATH for SSH. Both satisfy "the key material the create path needs" under one
+  # callback; consumers must not assume the value's shape across providers.
   @impl DeployEx.Cloud.Infrastructure
   def find_key_pair(_project_name, opts \\ []) do
     DeployEx.Terraform.find_pem_file(DeployEx.Config.terraform_folder_path(), opts[:pem])

--- a/lib/deploy_ex/cloud/oci_infrastructure.ex
+++ b/lib/deploy_ex/cloud/oci_infrastructure.ex
@@ -1,0 +1,84 @@
+defmodule DeployEx.Cloud.OciInfrastructure do
+  @moduledoc """
+  Network, image and key discovery for OCI. Config-driven ("discovery-lite") rather than
+  tenancy-queried like `DeployEx.AwsInfrastructure`: every callback reads a value directly out
+  of the `:oci` config namespace (via `DeployEx.Cloud.OciCli.setting/2`) instead of searching
+  the compartment, so launching an ad-hoc instance never needs a live OCI call just to find
+  out what to attach to. Missing config fails loudly (`:bad_request`) rather than launching
+  into a nil subnet/image.
+  """
+
+  @behaviour DeployEx.Cloud.Infrastructure
+
+  alias DeployEx.Cloud.OciCli
+
+  @impl DeployEx.Cloud.Infrastructure
+  def find_network(_opts \\ []) do
+    {:error,
+     ErrorMessage.not_implemented(
+       "OCI network (VCN) discovery is not implemented — subnet_id is configured directly, see find_subnet/1"
+     )}
+  end
+
+  @impl DeployEx.Cloud.Infrastructure
+  def find_subnet(opts \\ []) do
+    require_setting(opts, :subnet_id)
+  end
+
+  @impl DeployEx.Cloud.Infrastructure
+  def find_key_pair(_project_name, opts \\ []) do
+    DeployEx.Terraform.find_pem_file(DeployEx.Config.terraform_folder_path(), opts[:pem])
+  end
+
+  @impl DeployEx.Cloud.Infrastructure
+  def find_image(opts \\ []) do
+    case OciCli.setting(opts, :base_image) do
+      nil -> missing_setting_error(:base_image)
+      image when is_binary(image) -> {:ok, image}
+      image when is_list(image) -> per_app_image_not_implemented_error(image)
+    end
+  end
+
+  @doc "Identity the instance assumes, per `DeployEx.Cloud.Infrastructure`."
+  @impl DeployEx.Cloud.Infrastructure
+  def find_instance_identity(_opts \\ []) do
+    # OCI instance principals authorize by dynamic-group membership matched against the
+    # instance's OCID (or its compartment) after the fact, not by attaching a named identity
+    # at launch time the way an EC2 IAM instance profile does — there is nothing to return
+    # here, and that is the honest, working answer, not a gap.
+    {:ok, nil}
+  end
+
+  @impl DeployEx.Cloud.Infrastructure
+  def gather_infrastructure(opts \\ []) do
+    with {:ok, subnet_id} <- find_subnet(opts),
+         {:ok, image_id} <- find_image(opts),
+         {:ok, key_name} <- find_key_pair(nil, opts) do
+      {:ok, %{subnet_id: subnet_id, image_id: image_id, key_name: key_name}}
+    end
+  end
+
+  defp require_setting(opts, key) do
+    case OciCli.setting(opts, key) do
+      nil -> missing_setting_error(key)
+      value -> {:ok, value}
+    end
+  end
+
+  defp missing_setting_error(key) do
+    {:error,
+     ErrorMessage.bad_request(
+       "oci #{key} is required (config :deploy_ex, :oci, #{key}: \"...\")",
+       %{key: key}
+     )}
+  end
+
+  defp per_app_image_not_implemented_error(image) do
+    {:error,
+     ErrorMessage.not_implemented(
+       "per-app base_image resolution (keyword-list form) is not implemented this sprint — " <>
+         "configure base_image as a single OCID string",
+       %{base_image: image}
+     )}
+  end
+end

--- a/lib/deploy_ex/cloud/oci_infrastructure.ex
+++ b/lib/deploy_ex/cloud/oci_infrastructure.ex
@@ -57,6 +57,9 @@ defmodule DeployEx.Cloud.OciInfrastructure do
   @impl DeployEx.Cloud.Infrastructure
   def gather_infrastructure(opts \\ []) do
     with {:ok, subnet_id} <- find_subnet(opts),
+         # NOTE: run_instance does NOT read this bundle's subnet_id/image_id — it re-resolves
+         # both via require_setting from config (ticket OCI-BUNDLE-VS-CONFIG tracks unifying).
+         # The bundle exists so create_instance's preflight fails fast before any launch.
          {:ok, image_id} <- find_image(opts),
          {:ok, key_name} <- find_key_pair(nil, opts) do
       {:ok, %{subnet_id: subnet_id, image_id: image_id, key_name: key_name}}

--- a/lib/deploy_ex/cloud/oci_machine.ex
+++ b/lib/deploy_ex/cloud/oci_machine.ex
@@ -92,7 +92,8 @@ defmodule DeployEx.Cloud.OciMachine do
     with {:ok, compartment_id} <- require_compartment_id(opts),
          {:ok, availability_domain} <- require_setting(opts, :availability_domain),
          {:ok, subnet_id} <- require_setting(opts, :subnet_id),
-         {:ok, image_id} <- require_setting(opts, :base_image) do
+         {:ok, image_id} <- require_setting(opts, :base_image),
+         {:ok, ssh_public_key} <- require_setting(opts, :ssh_public_key) do
       command =
         "compute instance launch " <>
           "--compartment-id #{quote_arg(compartment_id)} " <>
@@ -102,7 +103,7 @@ defmodule DeployEx.Cloud.OciMachine do
           "--display-name #{quote_arg(spec.name)} " <>
           shape_flags(spec, opts) <>
           "--freeform-tags #{quote_arg(freeform_tags_json(spec.tags))} " <>
-          "--metadata #{quote_arg(metadata_json(spec.user_data))} " <>
+          "--metadata #{quote_arg(metadata_json(spec.user_data, ssh_public_key))} " <>
           "--assign-public-ip #{quote_arg("true")}"
 
       with {:ok, payload} <- OciCli.run_json(command, opts) do
@@ -129,6 +130,10 @@ defmodule DeployEx.Cloud.OciMachine do
     sleep_fn = opts[:sleep_fn] || (&Process.sleep/1)
 
     do_await_running(instance_ids, opts, retries, sleep_fn)
+  end
+
+  defp do_await_running([], _opts, _retries, _sleep_fn) do
+    {:error, ErrorMessage.bad_request("await_running requires at least one instance id")}
   end
 
   defp do_await_running(_instance_ids, _opts, 0, _sleep_fn) do
@@ -174,8 +179,14 @@ defmodule DeployEx.Cloud.OciMachine do
     tags |> Enum.into(%{}, fn {key, value} -> {to_string(key), value} end) |> Jason.encode!()
   end
 
-  defp metadata_json(user_data) do
-    Jason.encode!(%{"user_data" => Base.encode64(user_data)})
+  # ssh_authorized_keys is what OCI's cloud-init uses to seed the default user's
+  # ~/.ssh/authorized_keys — without it the instance boots keyless and every SSH step
+  # (readiness gate, upload, exec) times out against an unreachable box.
+  defp metadata_json(user_data, ssh_public_key) do
+    Jason.encode!(%{
+      "user_data" => Base.encode64(user_data),
+      "ssh_authorized_keys" => ssh_public_key
+    })
   end
 
   defp primary_vnic_addresses(instance_id, opts) do
@@ -192,7 +203,10 @@ defmodule DeployEx.Cloud.OciMachine do
     %Instance{
       id: summary["id"],
       type: nil,
-      state: summary["lifecycle-state"],
+      # Cloud.Instance :state contract is lowercase ("running"/"stopped"/"terminated" — what
+      # AwsMachine emits and exec/list compare against); OCI reports "RUNNING" etc., so
+      # normalize here in the adapter, never at call sites.
+      state: normalize_state(summary["lifecycle-state"]),
       private_ip: addresses.private_ip,
       public_ip: addresses.public_ip,
       ipv6: addresses.ipv6,
@@ -232,5 +246,8 @@ defmodule DeployEx.Cloud.OciMachine do
     {:error, ErrorMessage.not_implemented("DeployEx.Cloud.OciMachine.#{callback} is not implemented — not used by the loadtest path this sprint")}
   end
 
-  defp quote_arg(value), do: "'#{String.replace(to_string(value), "'", "'\\''")}'"
+  defp normalize_state(nil), do: nil
+  defp normalize_state(state), do: String.downcase(state)
+
+  defp quote_arg(value), do: OciCli.quote_arg(value)
 end

--- a/lib/deploy_ex/cloud/oci_machine.ex
+++ b/lib/deploy_ex/cloud/oci_machine.ex
@@ -93,7 +93,8 @@ defmodule DeployEx.Cloud.OciMachine do
          {:ok, availability_domain} <- require_setting(opts, :availability_domain),
          {:ok, subnet_id} <- require_setting(opts, :subnet_id),
          {:ok, image_id} <- require_setting(opts, :base_image),
-         {:ok, ssh_public_key} <- require_setting(opts, :ssh_public_key) do
+         {:ok, ssh_public_key} <- require_setting(opts, :ssh_public_key),
+         :ok <- validate_ssh_public_key(ssh_public_key) do
       command =
         "compute instance launch " <>
           "--compartment-id #{quote_arg(compartment_id)} " <>
@@ -151,6 +152,9 @@ defmodule DeployEx.Cloud.OciMachine do
     end
   end
 
+  # Compares OCI's RAW "RUNNING" — this path reads lifecycle-state straight off the get
+  # payload and never goes through instance_from_summary/normalize_state. If this loop is
+  # ever routed through describe_instance/2, the comparison must switch to "running".
   defp fetch_lifecycle_states(instance_ids, opts) do
     Enum.reduce_while(instance_ids, {:ok, []}, fn instance_id, {:ok, acc} ->
       case OciCli.run_json("compute instance get --instance-id #{quote_arg(instance_id)}", opts) do
@@ -244,6 +248,20 @@ defmodule DeployEx.Cloud.OciMachine do
 
   defp not_implemented_error(callback) do
     {:error, ErrorMessage.not_implemented("DeployEx.Cloud.OciMachine.#{callback} is not implemented — not used by the loadtest path this sprint")}
+  end
+
+  # authorized_keys wants the KEY CONTENTS ("ssh-ed25519 AAAA..."); a filesystem path pasted
+  # here would become a garbage authorized_keys line and the instance boots unreachable —
+  # the exact silent failure the ssh_authorized_keys wiring exists to prevent.
+  defp validate_ssh_public_key(key) do
+    if String.starts_with?(key, ["ssh-", "ecdsa-"]) do
+      :ok
+    else
+      {:error, ErrorMessage.bad_request(
+        "oci ssh_public_key must be the public key contents (\"ssh-ed25519 AAAA...\"), not a path",
+        %{value: key}
+      )}
+    end
   end
 
   defp normalize_state(nil), do: nil

--- a/lib/deploy_ex/cloud/oci_machine.ex
+++ b/lib/deploy_ex/cloud/oci_machine.ex
@@ -1,0 +1,236 @@
+defmodule DeployEx.Cloud.OciMachine do
+  @moduledoc """
+  OCI compute instance discovery and lifecycle, and the OCI implementation of
+  `DeployEx.Cloud.Machine`. Everything goes through `DeployEx.Cloud.OciCli` — no OCI SDK
+  exists for Elixir/Erlang, see `OciCli`'s moduledoc.
+
+  Tag filtering is entirely client-side (`oci compute instance list` has no reliable
+  server-side freeform-tag query across CLI versions), matching `AwsMachine`'s Regex-matcher
+  handling: filter after listing, never push a Regex into the CLI call.
+
+  `run_instance/2` and `terminate_instance/2` are optional callbacks (only a provider whose
+  lifecycle needs an ad-hoc launch implements them); `find_app_instances/3`, `start_instance/2`
+  and `stop_instance/2` are REQUIRED by `DeployEx.Cloud.Machine` but not used by the loadtest
+  path this sprint — honest `:not_implemented` stubs rather than either raising or inventing
+  untested behavior no caller has asked for.
+  """
+
+  @behaviour DeployEx.Cloud.Machine
+
+  alias DeployEx.Cloud.Instance
+  alias DeployEx.Cloud.OciCli
+
+  @default_shape "VM.Standard.E5.Flex"
+  @default_shape_ocpus 1
+  @default_shape_memory_gbs 8
+  @await_running_retries 30
+  @await_running_sleep_ms 10_000
+
+  @impl DeployEx.Cloud.Machine
+  def list_instances(tag_filters, opts \\ []) when is_list(tag_filters) do
+    with {:ok, compartment_id} <- require_compartment_id(opts),
+         {:ok, payload} <- OciCli.run_json("compute instance list --compartment-id #{quote_arg(compartment_id)} --all", opts) do
+      instances =
+        payload
+        |> Map.get("data", [])
+        |> Enum.filter(&matches_tag_filters?(&1, tag_filters))
+        |> Enum.map(&instance_from_summary/1)
+
+      {:ok, instances}
+    end
+  end
+
+  @impl DeployEx.Cloud.Machine
+  def find_app_instances(_project_name, _app_name, _opts \\ []) do
+    not_implemented_error("find_app_instances/3")
+  end
+
+  @impl DeployEx.Cloud.Machine
+  def describe_instance(instance_id, opts \\ []) do
+    with {:ok, payload} <- OciCli.run_json("compute instance get --instance-id #{quote_arg(instance_id)}", opts),
+         {:ok, addresses} <- primary_vnic_addresses(instance_id, opts) do
+      {:ok, instance_from_summary(Map.get(payload, "data", %{}), addresses)}
+    end
+  end
+
+  @impl DeployEx.Cloud.Machine
+  def start_instance(_instance_id, _opts \\ []), do: not_implemented_error("start_instance/2")
+
+  @impl DeployEx.Cloud.Machine
+  def stop_instance(_instance_id, _opts \\ []), do: not_implemented_error("stop_instance/2")
+
+  @impl DeployEx.Cloud.Machine
+  def fetch_tags(instance_id, opts \\ []) do
+    with {:ok, instance} <- describe_instance(instance_id, opts) do
+      {:ok, instance.tags}
+    end
+  end
+
+  @doc "Preferred reachable address for an instance. IPv6 wins when present."
+  @impl DeployEx.Cloud.Machine
+  def instance_address(%Instance{} = instance) do
+    case instance.ipv6 || instance.public_ip do
+      nil -> {:error, ErrorMessage.not_found("instance has no reachable address", %{id: instance.id})}
+      address -> {:ok, address}
+    end
+  end
+
+  @doc """
+  Translates a provider-neutral run-instance spec into `oci compute instance launch`.
+
+  Compartment, availability domain, subnet and image come from the `:oci` config namespace
+  (`OciCli.setting/2`), not from `spec.network` — that sub-map is EC2-shaped
+  (`ami_id`/`security_group_id`/`iam_instance_profile`), populated for AWS by
+  `AwsInfrastructure.gather_infrastructure/1`; OCI's `gather_infrastructure/1` populates its
+  own `subnet_id`/`image_id` keys instead, so `run_instance/2` resolves them directly from
+  config rather than depending on a key name the AWS-shaped struct never carries. `spec.name`,
+  `spec.instance_type`, `spec.user_data` and `spec.tags` ARE read from the spec — those are
+  genuinely provider-neutral.
+  """
+  @impl DeployEx.Cloud.Machine
+  def run_instance(spec, opts \\ []) do
+    with {:ok, compartment_id} <- require_compartment_id(opts),
+         {:ok, availability_domain} <- require_setting(opts, :availability_domain),
+         {:ok, subnet_id} <- require_setting(opts, :subnet_id),
+         {:ok, image_id} <- require_setting(opts, :base_image) do
+      command =
+        "compute instance launch " <>
+          "--compartment-id #{quote_arg(compartment_id)} " <>
+          "--availability-domain #{quote_arg(availability_domain)} " <>
+          "--subnet-id #{quote_arg(subnet_id)} " <>
+          "--image-id #{quote_arg(image_id)} " <>
+          "--display-name #{quote_arg(spec.name)} " <>
+          shape_flags(spec, opts) <>
+          "--freeform-tags #{quote_arg(freeform_tags_json(spec.tags))} " <>
+          "--metadata #{quote_arg(metadata_json(spec.user_data))} " <>
+          "--assign-public-ip #{quote_arg("true")}"
+
+      with {:ok, payload} <- OciCli.run_json(command, opts) do
+        {:ok, %Instance{id: get_in(payload, ["data", "id"])}}
+      end
+    end
+  end
+
+  @doc "Implements the optional `DeployEx.Cloud.Machine.terminate_instance/2` callback."
+  @impl DeployEx.Cloud.Machine
+  def terminate_instance(instance_id, opts \\ []) do
+    with {:ok, _output} <- OciCli.run("compute instance terminate --instance-id #{quote_arg(instance_id)} --force", opts) do
+      :ok
+    end
+  end
+
+  @doc """
+  Blocks until every instance id reports RUNNING. Implements the optional
+  `DeployEx.Cloud.Machine.await_running/2` callback.
+  """
+  @impl DeployEx.Cloud.Machine
+  def await_running(instance_ids, opts \\ []) do
+    retries = opts[:retries] || @await_running_retries
+    sleep_fn = opts[:sleep_fn] || (&Process.sleep/1)
+
+    do_await_running(instance_ids, opts, retries, sleep_fn)
+  end
+
+  defp do_await_running(_instance_ids, _opts, 0, _sleep_fn) do
+    {:error, ErrorMessage.failed_dependency("instance(s) did not report RUNNING before timeout")}
+  end
+
+  defp do_await_running(instance_ids, opts, retries, sleep_fn) do
+    with {:ok, states} <- fetch_lifecycle_states(instance_ids, opts) do
+      if Enum.all?(states, &(&1 === "RUNNING")) do
+        :ok
+      else
+        sleep_fn.(@await_running_sleep_ms)
+        do_await_running(instance_ids, opts, retries - 1, sleep_fn)
+      end
+    end
+  end
+
+  defp fetch_lifecycle_states(instance_ids, opts) do
+    Enum.reduce_while(instance_ids, {:ok, []}, fn instance_id, {:ok, acc} ->
+      case OciCli.run_json("compute instance get --instance-id #{quote_arg(instance_id)}", opts) do
+        {:ok, payload} -> {:cont, {:ok, acc ++ [get_in(payload, ["data", "lifecycle-state"])]}}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp shape_flags(spec, opts) do
+    shape = spec.instance_type || OciCli.setting(opts, :shape) || @default_shape
+    base = "--shape #{quote_arg(shape)} "
+
+    if String.ends_with?(shape, ".Flex") do
+      ocpus = OciCli.setting(opts, :shape_ocpus) || @default_shape_ocpus
+      memory_gbs = OciCli.setting(opts, :shape_memory_gbs) || @default_shape_memory_gbs
+      shape_config = Jason.encode!(%{"ocpus" => ocpus, "memoryInGBs" => memory_gbs})
+
+      base <> "--shape-config #{quote_arg(shape_config)} "
+    else
+      base
+    end
+  end
+
+  defp freeform_tags_json(tags) do
+    tags |> Enum.into(%{}, fn {key, value} -> {to_string(key), value} end) |> Jason.encode!()
+  end
+
+  defp metadata_json(user_data) do
+    Jason.encode!(%{"user_data" => Base.encode64(user_data)})
+  end
+
+  defp primary_vnic_addresses(instance_id, opts) do
+    with {:ok, payload} <- OciCli.run_json("compute instance list-vnics --instance-id #{quote_arg(instance_id)}", opts) do
+      vnic = payload |> Map.get("data", []) |> Enum.find(&(&1["is-primary"] === true)) || %{}
+
+      {:ok, %{public_ip: vnic["public-ip"], private_ip: vnic["private-ip"], ipv6: nil}}
+    end
+  end
+
+  defp instance_from_summary(summary, addresses \\ %{public_ip: nil, private_ip: nil, ipv6: nil}) do
+    tags = Map.get(summary, "freeform-tags", %{})
+
+    %Instance{
+      id: summary["id"],
+      type: nil,
+      state: summary["lifecycle-state"],
+      private_ip: addresses.private_ip,
+      public_ip: addresses.public_ip,
+      ipv6: addresses.ipv6,
+      launched_at: summary["time-created"],
+      name: summary["display-name"] || tags["Name"],
+      qa_node?: tags["QaNode"] === "true",
+      tags: tags
+    }
+  end
+
+  defp matches_tag_filters?(_summary, []), do: true
+
+  defp matches_tag_filters?(summary, tag_filters) do
+    tags = Map.get(summary, "freeform-tags", %{})
+
+    Enum.all?(tag_filters, fn {tag_name, matcher} -> matches_tag?(tags, tag_name, matcher) end)
+  end
+
+  defp matches_tag?(tags, tag_name, %Regex{} = regex) do
+    value = tags[tag_name]
+    not is_nil(value) and Regex.match?(regex, value)
+  end
+
+  defp matches_tag?(tags, tag_name, values) when is_list(values), do: tags[tag_name] in values
+  defp matches_tag?(tags, tag_name, value), do: tags[tag_name] === value
+
+  defp require_compartment_id(opts), do: require_setting(opts, :compartment_id)
+
+  defp require_setting(opts, key) do
+    case OciCli.setting(opts, key) do
+      nil -> {:error, ErrorMessage.bad_request("oci #{key} is required (config :deploy_ex, :oci, #{key}: \"...\")", %{key: key})}
+      value -> {:ok, value}
+    end
+  end
+
+  defp not_implemented_error(callback) do
+    {:error, ErrorMessage.not_implemented("DeployEx.Cloud.OciMachine.#{callback} is not implemented — not used by the loadtest path this sprint")}
+  end
+
+  defp quote_arg(value), do: "'#{String.replace(to_string(value), "'", "'\\''")}'"
+end

--- a/lib/deploy_ex/cloud/oci_machine.ex
+++ b/lib/deploy_ex/cloud/oci_machine.ex
@@ -257,9 +257,11 @@ defmodule DeployEx.Cloud.OciMachine do
     if String.starts_with?(key, ["ssh-", "ecdsa-"]) do
       :ok
     else
+      # Only a redacted prefix goes into details — a pasted PRIVATE key here would otherwise
+      # flow verbatim into logs/error trackers.
       {:error, ErrorMessage.bad_request(
         "oci ssh_public_key must be the public key contents (\"ssh-ed25519 AAAA...\"), not a path",
-        %{value: key}
+        %{value_prefix: String.slice(key, 0, 12) <> "…", length: byte_size(key)}
       )}
     end
   end

--- a/lib/deploy_ex/cloud/oci_object_store.ex
+++ b/lib/deploy_ex/cloud/oci_object_store.ex
@@ -168,5 +168,5 @@ defmodule DeployEx.Cloud.OciObjectStore do
     Path.join(System.tmp_dir!(), "deploy_ex_oci_#{kind}_#{System.unique_integer([:positive])}")
   end
 
-  defp quote_arg(value), do: "'#{String.replace(to_string(value), "'", "'\\''")}'"
+  defp quote_arg(value), do: OciCli.quote_arg(value)
 end

--- a/lib/deploy_ex/cloud/oci_security_group.ex
+++ b/lib/deploy_ex/cloud/oci_security_group.ex
@@ -184,5 +184,5 @@ defmodule DeployEx.Cloud.OciSecurityGroup do
     )
   end
 
-  defp quote_arg(value), do: "'#{String.replace(to_string(value), "'", "'\\''")}'"
+  defp quote_arg(value), do: OciCli.quote_arg(value)
 end

--- a/lib/deploy_ex/cloud/providers/oci.ex
+++ b/lib/deploy_ex/cloud/providers/oci.ex
@@ -5,7 +5,9 @@ defmodule DeployEx.Cloud.Providers.Oci do
   Slots fill per phase. One invented ahead of its phase would be untested guesswork that reads
   as working code, so an unfilled slot stays `nil` and surfaces as
   `{:error, %ErrorMessage{code: :not_implemented}}` rather than a plausible default.
-  `object_store`, `inventory` and `security` are filled; compute and networking are not.
+  `object_store`, `inventory`, `security`, `machine` and `infrastructure` are filled;
+  `completion_marker` and `cli_adapter` are not (the latter has no consumer yet — every
+  filled capability already talks to `DeployEx.Cloud.OciCli` directly).
 
   The config schema is the exception: it is strict from the start so a typo'd key fails at
   task start rather than mid-apply. Every key is optional — the schema catches mistakes, it
@@ -41,7 +43,9 @@ defmodule DeployEx.Cloud.Providers.Oci do
   def capabilities do
     %{
       object_store: DeployEx.Cloud.OciObjectStore,
-      security: DeployEx.Cloud.OciSecurityGroup
+      security: DeployEx.Cloud.OciSecurityGroup,
+      machine: DeployEx.Cloud.OciMachine,
+      infrastructure: DeployEx.Cloud.OciInfrastructure
     }
   end
 
@@ -73,7 +77,10 @@ defmodule DeployEx.Cloud.Providers.Oci do
   @impl DeployEx.Cloud.Provider
   def default_ssh_user, do: "ubuntu"
 
-  # Filled by Phase 3 (oci CLI adapter).
+  # `DeployEx.Cloud.OciCli` already exists and is the CLI runner every OCI capability
+  # (object_store, security, machine, infrastructure) calls directly — but nothing reads this
+  # descriptor slot to dispatch to it, so setting it here would be a dangling reference with
+  # no consumer. Fill it once something actually looks a provider's cli_adapter up generically.
   @impl DeployEx.Cloud.Provider
   def cli_adapter, do: nil
 end

--- a/lib/deploy_ex/cloud/providers/oci.ex
+++ b/lib/deploy_ex/cloud/providers/oci.ex
@@ -36,7 +36,8 @@ defmodule DeployEx.Cloud.Providers.Oci do
     state_profile: [type: {:or, [:string, nil]}],
     log_bucket: [type: {:or, [:string, nil]}],
     log_region: [type: {:or, [:string, nil]}],
-    resource_group: [type: {:or, [:string, nil]}]
+    resource_group: [type: {:or, [:string, nil]}],
+    ssh_public_key: [type: {:or, [:string, nil]}]
   ]
 
   @impl DeployEx.Cloud.Provider

--- a/lib/deploy_ex/cloud/providers/oci.ex
+++ b/lib/deploy_ex/cloud/providers/oci.ex
@@ -22,6 +22,7 @@ defmodule DeployEx.Cloud.Providers.Oci do
     compartment_id: [type: {:or, [:string, nil]}],
     namespace: [type: {:or, [:string, nil]}],
     availability_domain: [type: {:or, [:string, nil]}],
+    subnet_id: [type: {:or, [:string, nil]}],
     base_image: [type: {:or, [:keyword_list, :string, nil]}],
     shape: [type: {:or, [:string, nil]}],
     shape_ocpus: [type: {:or, [:pos_integer, nil]}],

--- a/lib/deploy_ex/config.ex
+++ b/lib/deploy_ex/config.ex
@@ -6,14 +6,18 @@ defmodule DeployEx.Config do
   def cloud_provider, do: Application.get_env(@app, :cloud_provider, :aws)
 
   @doc """
-  Reads one key from the `:oci` config namespace.
+  Reads one key from a non-AWS provider's config namespace (`config :deploy_ex, provider, ...`).
 
-  Namespaced rather than flat because `DeployEx.Cloud.Providers.Oci`'s `config_schema/0`
-  validates that namespace strictly — a typo'd key fails at task start instead of mid-apply.
-  The AWS keys stay flat and permissively validated so existing configs keep working.
+  Namespaced rather than flat because a non-AWS descriptor's `config_schema/0` validates that
+  namespace strictly — a typo'd key fails at task start instead of mid-apply. The AWS keys stay
+  flat and permissively validated so existing configs keep working.
   """
+  @spec provider_setting(atom(), atom()) :: term()
+  def provider_setting(provider, key), do: @app |> Application.get_env(provider, []) |> Keyword.get(key)
+
+  @doc "Reads one key from the `:oci` config namespace. See `provider_setting/2`."
   @spec oci_setting(atom()) :: term()
-  def oci_setting(key), do: @app |> Application.get_env(:oci, []) |> Keyword.get(key)
+  def oci_setting(key), do: provider_setting(:oci, key)
 
   # Follows the key layout already in use in the state bucket (oracle/<region>/<stack>/…),
   # so deploy_ex state sits alongside states written by other tooling without colliding.

--- a/lib/deploy_ex/k6_runner.ex
+++ b/lib/deploy_ex/k6_runner.ex
@@ -374,14 +374,26 @@ defmodule DeployEx.K6Runner do
     echo "k6 Runner setup starting..."
 
     apt-get update -y -o DPkg::Lock::Timeout=300
-    apt-get install -y -o DPkg::Lock::Timeout=300 curl gnupg ca-certificates
+    apt-get install -y -o DPkg::Lock::Timeout=300 curl gnupg ca-certificates tar
 
+    # k6's apt repo (dl.k6.io/deb) ships amd64 only, so on arm64 hosts (e.g. OCI's
+    # Always-Free VM.Standard.A1.Flex) `apt-get install k6` fails with "Unable to locate
+    # package k6". k6 publishes an official linux-arm64 binary per GitHub release, so arm64
+    # hosts install that tarball; amd64 keeps the apt path unchanged (AWS invariance).
+    # Version pinned for a reproducible provision (bump deliberately, same as apt's stable).
+    if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+    curl -fsSL https://github.com/grafana/k6/releases/download/v2.2.0/k6-v2.2.0-linux-arm64.tar.gz -o /tmp/k6.tar.gz
+    tar -xzf /tmp/k6.tar.gz -C /tmp
+    cp /tmp/k6-v2.2.0-linux-arm64/k6 /usr/local/bin/k6
+    chmod 0755 /usr/local/bin/k6
+    else
     mkdir -p /etc/apt/keyrings
     curl -fsSL https://dl.k6.io/key.gpg | gpg --dearmor -o /etc/apt/keyrings/k6.gpg
     echo "deb [signed-by=/etc/apt/keyrings/k6.gpg] https://dl.k6.io/deb stable main" | tee /etc/apt/sources.list.d/k6.list
 
     apt-get update -y -o DPkg::Lock::Timeout=300
     apt-get install -y -o DPkg::Lock::Timeout=300 k6
+    fi
 
     mkdir -p /srv/k6/scripts
     chown -R #{ssh_user}:#{ssh_user} /srv/k6

--- a/lib/deploy_ex/k6_runner.ex
+++ b/lib/deploy_ex/k6_runner.ex
@@ -126,10 +126,26 @@ defmodule DeployEx.K6Runner do
   billing).
   """
   def find_runners_from_ec2(opts \\ []) do
-    region = opts[:region] || DeployEx.Config.aws_region()
-    resource_group = opts[:resource_group] || DeployEx.Config.aws_resource_group()
+    case DeployEx.Cloud.active_provider(opts) do
+      :aws ->
+        region = opts[:region] || DeployEx.Config.aws_region()
+        resource_group = opts[:resource_group] || DeployEx.Config.aws_resource_group()
 
-    find_runners_from_ec2_page(region, resource_group, opts, nil, [])
+        find_runners_from_ec2_page(region, resource_group, opts, nil, [])
+
+      provider ->
+        # AWS-only EC2 DescribeInstances fallback path (see the moduledoc above and the
+        # module doc note at the top of this section) — deliberately NOT routed through
+        # Cloud.capability(:machine) this sprint (docs/superpowers/plans/lt-oci/spec.md § S2
+        # adds the OCI-native runner-listing path). Erroring here instead of running the EC2
+        # query under a non-AWS provider stops list/destroy_instance from printing another
+        # provider's leftover AWS runners as if they belonged to the active one.
+        {:error,
+         ErrorMessage.not_implemented(
+           "find_runners_from_ec2 is AWS-only (EC2 DescribeInstances) — not available for #{inspect(provider)}",
+           %{provider: provider}
+         )}
+    end
   end
 
   defp find_runners_from_ec2_page(region, resource_group, opts, next_token, acc) do
@@ -167,26 +183,31 @@ defmodule DeployEx.K6Runner do
 
   defp describe_instances_next_token(_response), do: nil
 
-  def verify_instance_exists(nil), do: {:ok, nil}
+  def verify_instance_exists(runner, opts \\ [])
 
-  def verify_instance_exists(%__MODULE__{instance_id: instance_id} = runner) do
-    case DeployEx.AwsMachine.find_instances_by_id([instance_id]) do
-      {:ok, [instance]} ->
-        updated = %{runner |
-          public_ip: instance["ipAddress"],
-          ipv6_address: instance["ipv6Address"],
-          private_ip: instance["privateIpAddress"],
-          state: instance["instanceState"]["name"]
-        }
+  def verify_instance_exists(nil, _opts), do: {:ok, nil}
 
-        {:ok, updated}
+  def verify_instance_exists(%__MODULE__{instance_id: instance_id} = runner, opts) do
+    with {:ok, machine} <- DeployEx.Cloud.capability(:machine, opts) do
+      case machine.describe_instance(instance_id, opts) do
+        {:ok, instance} ->
+          updated = %{runner |
+            public_ip: instance.public_ip,
+            ipv6_address: instance.ipv6,
+            private_ip: instance.private_ip,
+            state: instance.state
+          }
 
-      {:error, %ErrorMessage{code: :not_found}} ->
-        :ok = delete_state(runner, [])
-        {:ok, nil}
+          {:ok, updated}
 
-      error ->
-        error
+        {:error, %ErrorMessage{code: :not_found}} ->
+          with :ok <- delete_state(runner, opts) do
+            {:ok, nil}
+          end
+
+        error ->
+          error
+      end
     end
   end
 

--- a/lib/deploy_ex/k6_runner.ex
+++ b/lib/deploy_ex/k6_runner.ex
@@ -23,8 +23,7 @@ defmodule DeployEx.K6Runner do
   @default_instance_type "t3.small"
 
   def create_instance(params, opts \\ []) do
-    region = opts[:region] || DeployEx.Config.aws_region()
-    resource_group = opts[:resource_group] || DeployEx.Config.aws_resource_group()
+    resource_group = opts[:resource_group] || DeployEx.Cloud.resource_group(opts)
     environment = opts[:environment] || DeployEx.Config.env()
 
     instance_name = build_instance_name(environment)
@@ -39,46 +38,35 @@ defmodule DeployEx.K6Runner do
       {:Type, "Load Testing"}
     ]
 
-    user_data = build_user_data()
+    spec = %{
+      name: instance_name,
+      instance_type: instance_type,
+      user_data: build_user_data(opts),
+      tags: tags,
+      network: %{
+        key_name: params[:key_name],
+        subnet_id: params[:subnet_id],
+        security_group_id: params[:security_group_id],
+        ami_id: params[:ami_id],
+        iam_instance_profile: params[:iam_instance_profile]
+      }
+    }
 
-    run_opts = [
-      {"InstanceType", instance_type},
-      {"KeyName", params[:key_name]},
-      {"NetworkInterface.1.DeviceIndex", "0"},
-      {"NetworkInterface.1.SubnetId", params[:subnet_id]},
-      {"NetworkInterface.1.SecurityGroupId.1", params[:security_group_id]},
-      {"NetworkInterface.1.AssociatePublicIpAddress", "true"},
-      {"UserData", Base.encode64(user_data)},
-      iam_instance_profile: [name: params[:iam_instance_profile]],
-      tag_specifications: [{:instance, tags}]
-    ]
-
-    params[:ami_id]
-    |> ExAws.EC2.run_instances(1, 1, run_opts)
-    |> ExAws.request(region: region)
-    |> handle_run_instances_response()
-    |> case do
-      {:ok, instance_id} ->
-        runner = %__MODULE__{
-          instance_id: instance_id,
-          instance_name: instance_name,
-          created_at: DateTime.utc_now() |> DateTime.to_iso8601()
-        }
-
-        {:ok, runner}
-
-      error ->
-        error
+    with {:ok, machine} <- DeployEx.Cloud.capability(:machine, opts),
+         {:ok, instance} <- machine.run_instance(spec, opts) do
+      {:ok,
+       %__MODULE__{
+         instance_id: instance.id,
+         instance_name: instance_name,
+         created_at: DateTime.utc_now() |> DateTime.to_iso8601()
+       }}
     end
   end
 
   def terminate_instance(instance_id, opts \\ []) do
-    region = opts[:region] || DeployEx.Config.aws_region()
-
-    [instance_id]
-    |> ExAws.EC2.terminate_instances()
-    |> ExAws.request(region: region)
-    |> handle_terminate_response()
+    with {:ok, machine} <- DeployEx.Cloud.capability(:machine, opts) do
+      machine.terminate_instance(instance_id, opts)
+    end
   end
 
   def terminate_runner(%__MODULE__{} = runner, opts \\ []) do
@@ -232,27 +220,23 @@ defmodule DeployEx.K6Runner do
   end
 
   def save_state(%__MODULE__{instance_id: instance_id} = runner, opts \\ []) do
-    region = opts[:region] || DeployEx.Config.aws_region()
-    bucket = opts[:bucket] || DeployEx.Config.aws_release_bucket()
+    bucket = opts[:bucket] || DeployEx.Cloud.release_bucket(opts)
 
-    bucket
-    |> ExAws.S3.put_object(state_key(instance_id), to_json(runner))
-    |> ExAws.request(region: region)
-    |> handle_put_response()
+    with {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts),
+         :ok <- object_store.put_object(bucket, state_key(instance_id), to_json(runner), opts) do
+      {:ok, :saved}
+    end
   end
 
   def fetch_state(instance_id, opts \\ []) do
-    region = opts[:region] || DeployEx.Config.aws_region()
-    bucket = opts[:bucket] || DeployEx.Config.aws_release_bucket()
+    bucket = opts[:bucket] || DeployEx.Cloud.release_bucket(opts)
 
-    bucket
-    |> ExAws.S3.get_object(state_key(instance_id))
-    |> ExAws.request(region: region)
-    |> handle_get_response()
-    |> case do
-      {:ok, json} -> {:ok, from_json(json)}
-      {:error, %ErrorMessage{code: :not_found}} -> {:ok, nil}
-      error -> error
+    with {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts) do
+      case object_store.get_object(bucket, state_key(instance_id), opts) do
+        {:ok, json} -> {:ok, from_json(json)}
+        {:error, %ErrorMessage{code: :not_found}} -> {:ok, nil}
+        error -> error
+      end
     end
   end
 
@@ -265,60 +249,24 @@ defmodule DeployEx.K6Runner do
   list.
   """
   def fetch_all_runners(opts \\ []) do
-    region = opts[:region] || DeployEx.Config.aws_region()
-    bucket = opts[:bucket] || DeployEx.Config.aws_release_bucket()
-    request_fn = opts[:request_fn] || (&ExAws.request/2)
+    bucket = opts[:bucket] || DeployEx.Cloud.release_bucket(opts)
+    list_opts = Keyword.put(opts, :prefix, "#{@state_prefix}/")
 
-    with {:ok, contents} <- list_runner_state_objects(bucket, region, opts) do
-      runners = Enum.map(contents, fn content ->
-        case ExAws.S3.get_object(bucket, content.key) |> request_fn.(region: region) do
-          {:ok, %{body: body}} -> from_json(body)
-          _ -> nil
-        end
-      end)
-      |> Enum.reject(&is_nil/1)
+    with {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts),
+         {:ok, keys} <- object_store.list_objects(bucket, list_opts) do
+      runners =
+        keys
+        |> Enum.map(&fetch_runner_state(object_store, bucket, &1, opts))
+        |> Enum.reject(&is_nil/1)
 
       {:ok, runners}
     end
   end
 
-  defp list_runner_state_objects(bucket, region, opts) do
-    list_runner_state_objects_page(bucket, region, opts, nil, [])
-  end
-
-  defp list_runner_state_objects_page(bucket, region, opts, marker, acc) do
-    request_fn = opts[:request_fn] || (&ExAws.request/2)
-    list_opts = if marker, do: [prefix: "#{@state_prefix}/", marker: marker], else: [prefix: "#{@state_prefix}/"]
-
-    response =
-      bucket
-      |> ExAws.S3.list_objects(list_opts)
-      |> request_fn.(region: region)
-
-    case response do
-      {:ok, %{body: %{contents: contents} = body}} when is_list(contents) ->
-        accumulated = acc ++ contents
-
-        if truncated_listing?(body) and not Enum.empty?(contents) do
-          list_runner_state_objects_page(bucket, region, opts, next_listing_marker(body, contents), accumulated)
-        else
-          {:ok, accumulated}
-        end
-
-      {:ok, _} ->
-        {:ok, acc}
-
-      {:error, error} ->
-        {:error, ErrorMessage.failed_dependency("failed to list k6 runner states", %{error: error})}
-    end
-  end
-
-  defp truncated_listing?(body), do: Map.get(body, :is_truncated) in [true, "true"]
-
-  defp next_listing_marker(body, contents) do
-    case Map.get(body, :next_marker) do
-      marker when is_binary(marker) and marker !== "" -> marker
-      _absent -> contents |> List.last() |> Map.fetch!(:key)
+  defp fetch_runner_state(object_store, bucket, key, opts) do
+    case object_store.get_object(bucket, key, opts) do
+      {:ok, body} -> from_json(body)
+      _error -> nil
     end
   end
 
@@ -327,13 +275,15 @@ defmodule DeployEx.K6Runner do
   end
 
   def delete_state(instance_id, opts) when is_binary(instance_id) do
-    region = opts[:region] || DeployEx.Config.aws_region()
-    bucket = opts[:bucket] || DeployEx.Config.aws_release_bucket()
+    bucket = opts[:bucket] || DeployEx.Cloud.release_bucket(opts)
 
-    bucket
-    |> ExAws.S3.delete_object(state_key(instance_id))
-    |> ExAws.request(region: region)
-    |> handle_delete_response()
+    with {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts) do
+      case object_store.delete_object(bucket, state_key(instance_id), opts) do
+        :ok -> :ok
+        {:error, %ErrorMessage{code: :not_found}} -> :ok
+        error -> error
+      end
+    end
   end
 
   # Serialization
@@ -373,7 +323,9 @@ defmodule DeployEx.K6Runner do
   # User Data
 
   @doc false
-  def build_user_data do
+  def build_user_data(opts \\ []) do
+    ssh_user = DeployEx.Cloud.ssh_user(opts)
+
     """
     #!/bin/bash
     set -euo pipefail
@@ -393,7 +345,7 @@ defmodule DeployEx.K6Runner do
     apt-get install -y -o DPkg::Lock::Timeout=300 k6
 
     mkdir -p /srv/k6/scripts
-    chown -R admin:admin /srv/k6
+    chown -R #{ssh_user}:#{ssh_user} /srv/k6
 
     echo "k6 Runner setup complete!"
     k6 version
@@ -405,39 +357,8 @@ defmodule DeployEx.K6Runner do
     "K6-Runner-#{environment}-#{timestamp}"
   end
 
-  # AWS Response Handlers
-
-  defp handle_run_instances_response({:ok, %{body: body}}) do
-    case XmlToMap.naive_map(body) do
-      %{"RunInstancesResponse" => %{"instancesSet" => %{"item" => %{"instanceId" => instance_id}}}} ->
-        {:ok, instance_id}
-
-      %{"RunInstancesResponse" => %{"instancesSet" => %{"item" => [%{"instanceId" => instance_id} | _]}}} ->
-        {:ok, instance_id}
-
-      structure ->
-        {:error, ErrorMessage.bad_request(
-          "couldn't parse run instances response from aws",
-          %{structure: structure}
-        )}
-    end
-  end
-
-  defp handle_run_instances_response({:error, {:http_error, status_code, %{body: body}}}) do
-    {:error, apply(ErrorMessage, ErrorMessage.http_code_reason_atom(status_code), [
-      "error creating k6 runner instance",
-      %{error_body: body}
-    ])}
-  end
-
-  defp handle_terminate_response({:ok, _}), do: :ok
-
-  defp handle_terminate_response({:error, {:http_error, status_code, %{body: body}}}) do
-    {:error, apply(ErrorMessage, ErrorMessage.http_code_reason_atom(status_code), [
-      "error terminating k6 runner instance",
-      %{error_body: body}
-    ])}
-  end
+  # AWS Response Handlers (find_runners_from_ec2 stays a direct AWS EC2 pagination path —
+  # LT-OCI S1 keeps this pagination intact rather than routing it through Cloud.capability)
 
   defp handle_describe_instances({:ok, %{body: body}}) do
     case XmlToMap.naive_map(body) do
@@ -498,43 +419,4 @@ defmodule DeployEx.K6Runner do
   end
 
   defp parse_instance_tags(_), do: %{}
-
-  defp handle_get_response({:ok, %{body: body}}), do: {:ok, body}
-
-  defp handle_get_response({:error, {:http_error, 404, _}}) do
-    {:error, ErrorMessage.not_found("k6 runner state not found")}
-  end
-
-  defp handle_get_response({:error, {:http_error, status, reason}}) do
-    {:error, apply(ErrorMessage, ErrorMessage.http_code_reason_atom(status), ["aws failure", %{reason: reason}])}
-  end
-
-  defp handle_get_response({:error, error}) when is_binary(error) do
-    {:error, ErrorMessage.failed_dependency("aws failure: #{error}")}
-  end
-
-  defp handle_put_response({:ok, _}), do: {:ok, :saved}
-
-  defp handle_put_response({:error, {:http_error, status, reason}}) do
-    {:error, apply(ErrorMessage, ErrorMessage.http_code_reason_atom(status), ["aws failure", %{reason: reason}])}
-  end
-
-  defp handle_put_response({:error, error}) when is_binary(error) do
-    {:error, ErrorMessage.failed_dependency("aws failure: #{error}")}
-  end
-
-  defp handle_put_response({:error, error}) do
-    {:error, ErrorMessage.failed_dependency("aws failure", %{error: error})}
-  end
-
-  defp handle_delete_response({:ok, _}), do: :ok
-  defp handle_delete_response({:error, {:http_error, 404, _}}), do: :ok
-
-  defp handle_delete_response({:error, {:http_error, status, reason}}) do
-    {:error, apply(ErrorMessage, ErrorMessage.http_code_reason_atom(status), ["aws failure", %{reason: reason}])}
-  end
-
-  defp handle_delete_response({:error, error}) when is_binary(error) do
-    {:error, ErrorMessage.failed_dependency("aws failure: #{error}")}
-  end
 end

--- a/lib/deploy_ex/k6_runner.ex
+++ b/lib/deploy_ex/k6_runner.ex
@@ -23,49 +23,67 @@ defmodule DeployEx.K6Runner do
   @default_instance_type "t3.small"
 
   def create_instance(params, opts \\ []) do
-    resource_group = opts[:resource_group] || DeployEx.Cloud.resource_group(opts)
     environment = opts[:environment] || DeployEx.Config.env()
 
-    instance_name = build_instance_name(environment)
-    instance_type = params[:instance_type] || @default_instance_type
+    with {:ok, resource_group} <- resolve_resource_group(opts) do
+      instance_name = build_instance_name(environment)
+      instance_type = params[:instance_type] || @default_instance_type
 
-    tags = [
-      {:Name, instance_name},
-      {:Group, resource_group},
-      {:Environment, environment},
-      {:ManagedBy, "DeployEx"},
-      {:K6Runner, "true"},
-      {:Type, "Load Testing"}
-    ]
+      tags = [
+        {:Name, instance_name},
+        {:Group, resource_group},
+        {:Environment, environment},
+        {:ManagedBy, "DeployEx"},
+        {:K6Runner, "true"},
+        {:Type, "Load Testing"}
+      ]
 
-    spec = %{
-      name: instance_name,
-      instance_type: instance_type,
-      user_data: build_user_data(opts),
-      tags: tags,
-      network: %{
-        key_name: params[:key_name],
-        subnet_id: params[:subnet_id],
-        security_group_id: params[:security_group_id],
-        ami_id: params[:ami_id],
-        iam_instance_profile: params[:iam_instance_profile]
+      spec = %{
+        name: instance_name,
+        instance_type: instance_type,
+        user_data: build_user_data(opts),
+        tags: tags,
+        network: %{
+          key_name: params[:key_name],
+          subnet_id: params[:subnet_id],
+          security_group_id: params[:security_group_id],
+          ami_id: params[:ami_id],
+          iam_instance_profile: params[:iam_instance_profile]
+        }
       }
-    }
 
-    with {:ok, machine} <- DeployEx.Cloud.capability(:machine, opts),
-         {:ok, instance} <- machine.run_instance(spec, opts) do
-      {:ok,
-       %__MODULE__{
-         instance_id: instance.id,
-         instance_name: instance_name,
-         created_at: DateTime.utc_now() |> DateTime.to_iso8601()
-       }}
+      with {:ok, machine} <- DeployEx.Cloud.capability(:machine, opts),
+           {:ok, instance} <- machine.run_instance(spec, opts) do
+        {:ok,
+         %__MODULE__{
+           instance_id: instance.id,
+           instance_name: instance_name,
+           created_at: DateTime.utc_now() |> DateTime.to_iso8601()
+         }}
+      end
     end
   end
 
   def terminate_instance(instance_id, opts \\ []) do
     with {:ok, machine} <- DeployEx.Cloud.capability(:machine, opts) do
       machine.terminate_instance(instance_id, opts)
+    end
+  end
+
+  # An explicit opts override always wins and skips the Cloud lookup entirely — a caller who
+  # already knows the bucket/resource-group should never trip an "unset config" error for a
+  # provider that has not configured the key.
+  defp resolve_resource_group(opts) do
+    case opts[:resource_group] do
+      nil -> DeployEx.Cloud.resource_group(opts)
+      resource_group -> {:ok, resource_group}
+    end
+  end
+
+  defp resolve_bucket(opts) do
+    case opts[:bucket] do
+      nil -> DeployEx.Cloud.release_bucket(opts)
+      bucket -> {:ok, bucket}
     end
   end
 
@@ -220,18 +238,16 @@ defmodule DeployEx.K6Runner do
   end
 
   def save_state(%__MODULE__{instance_id: instance_id} = runner, opts \\ []) do
-    bucket = opts[:bucket] || DeployEx.Cloud.release_bucket(opts)
-
-    with {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts),
+    with {:ok, bucket} <- resolve_bucket(opts),
+         {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts),
          :ok <- object_store.put_object(bucket, state_key(instance_id), to_json(runner), opts) do
       {:ok, :saved}
     end
   end
 
   def fetch_state(instance_id, opts \\ []) do
-    bucket = opts[:bucket] || DeployEx.Cloud.release_bucket(opts)
-
-    with {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts) do
+    with {:ok, bucket} <- resolve_bucket(opts),
+         {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts) do
       case object_store.get_object(bucket, state_key(instance_id), opts) do
         {:ok, json} -> {:ok, from_json(json)}
         {:error, %ErrorMessage{code: :not_found}} -> {:ok, nil}
@@ -249,10 +265,10 @@ defmodule DeployEx.K6Runner do
   list.
   """
   def fetch_all_runners(opts \\ []) do
-    bucket = opts[:bucket] || DeployEx.Cloud.release_bucket(opts)
     list_opts = Keyword.put(opts, :prefix, "#{@state_prefix}/")
 
-    with {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts),
+    with {:ok, bucket} <- resolve_bucket(opts),
+         {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts),
          {:ok, keys} <- object_store.list_objects(bucket, list_opts) do
       runners =
         keys
@@ -275,9 +291,8 @@ defmodule DeployEx.K6Runner do
   end
 
   def delete_state(instance_id, opts) when is_binary(instance_id) do
-    bucket = opts[:bucket] || DeployEx.Cloud.release_bucket(opts)
-
-    with {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts) do
+    with {:ok, bucket} <- resolve_bucket(opts),
+         {:ok, object_store} <- DeployEx.Cloud.capability(:object_store, opts) do
       case object_store.delete_object(bucket, state_key(instance_id), opts) do
         :ok -> :ok
         {:error, %ErrorMessage{code: :not_found}} -> :ok

--- a/lib/deploy_ex/k6_runner.ex
+++ b/lib/deploy_ex/k6_runner.ex
@@ -20,14 +20,13 @@ defmodule DeployEx.K6Runner do
   ]
 
   @state_prefix "k6-runners"
-  @default_instance_type "t3.small"
 
   def create_instance(params, opts \\ []) do
     environment = opts[:environment] || DeployEx.Config.env()
 
     with {:ok, resource_group} <- resolve_resource_group(opts) do
       instance_name = build_instance_name(environment)
-      instance_type = params[:instance_type] || @default_instance_type
+      instance_type = params[:instance_type]
 
       tags = [
         {:Name, instance_name},

--- a/lib/deploy_ex/k6_runner.ex
+++ b/lib/deploy_ex/k6_runner.ex
@@ -97,7 +97,7 @@ defmodule DeployEx.K6Runner do
   def find_or_create_runner(params, opts \\ []) do
     case fetch_all_runners(opts) do
       {:ok, [runner | _]} ->
-        case verify_instance_exists(runner) do
+        case verify_instance_exists(runner, opts) do
           {:ok, verified} when not is_nil(verified) -> {:ok, verified}
           _ -> do_create_runner(params, opts)
         end
@@ -224,7 +224,7 @@ defmodule DeployEx.K6Runner do
 
   defp resolve_default_runner(opts, k6_runner_impl) do
     case k6_runner_impl.fetch_all_runners(opts) do
-      {:ok, [runner | _]} -> verify_resolved_runner(runner, k6_runner_impl)
+      {:ok, [runner | _]} -> verify_resolved_runner(runner, opts, k6_runner_impl)
       {:ok, empty} when empty in [nil, []] -> {:error, no_runner_error()}
       error -> error
     end
@@ -233,13 +233,13 @@ defmodule DeployEx.K6Runner do
   defp resolve_runner_by_instance_id(instance_id, opts, k6_runner_impl) do
     case k6_runner_impl.fetch_state(instance_id, opts) do
       {:ok, nil} -> {:error, no_runner_error()}
-      {:ok, runner} -> verify_resolved_runner(runner, k6_runner_impl)
+      {:ok, runner} -> verify_resolved_runner(runner, opts, k6_runner_impl)
       error -> error
     end
   end
 
-  defp verify_resolved_runner(runner, k6_runner_impl) do
-    case k6_runner_impl.verify_instance_exists(runner) do
+  defp verify_resolved_runner(runner, opts, k6_runner_impl) do
+    case k6_runner_impl.verify_instance_exists(runner, opts) do
       {:ok, nil} -> {:error, no_runner_error()}
       {:ok, verified} -> {:ok, verified}
       error -> error

--- a/lib/deploy_ex/k6_runner.ex
+++ b/lib/deploy_ex/k6_runner.ex
@@ -126,25 +126,29 @@ defmodule DeployEx.K6Runner do
   billing).
   """
   def find_runners_from_ec2(opts \\ []) do
-    case DeployEx.Cloud.active_provider(opts) do
-      :aws ->
-        region = opts[:region] || DeployEx.Config.aws_region()
-        resource_group = opts[:resource_group] || DeployEx.Config.aws_resource_group()
+    # Cloud.aws?/1, not a bare `case active_provider(opts) do :aws -> ...` — the latter answers
+    # "no" for the descriptor MODULE override (the put_env-free test seam capability/2 and
+    # validate_config/2 already accept), which is a real AWS override, not a different provider.
+    # This exact gap has recurred (F1): once in this module's own config accessors, now here.
+    if DeployEx.Cloud.aws?(opts) do
+      region = opts[:region] || DeployEx.Config.aws_region()
+      resource_group = opts[:resource_group] || DeployEx.Config.aws_resource_group()
 
-        find_runners_from_ec2_page(region, resource_group, opts, nil, [])
+      find_runners_from_ec2_page(region, resource_group, opts, nil, [])
+    else
+      # AWS-only EC2 DescribeInstances fallback path (see the moduledoc above and the
+      # module doc note at the top of this section) — deliberately NOT routed through
+      # Cloud.capability(:machine) this sprint (docs/superpowers/plans/lt-oci/spec.md § S2
+      # adds the OCI-native runner-listing path). Erroring here instead of running the EC2
+      # query under a non-AWS provider stops list/destroy_instance from printing another
+      # provider's leftover AWS runners as if they belonged to the active one.
+      provider = DeployEx.Cloud.active_provider(opts)
 
-      provider ->
-        # AWS-only EC2 DescribeInstances fallback path (see the moduledoc above and the
-        # module doc note at the top of this section) — deliberately NOT routed through
-        # Cloud.capability(:machine) this sprint (docs/superpowers/plans/lt-oci/spec.md § S2
-        # adds the OCI-native runner-listing path). Erroring here instead of running the EC2
-        # query under a non-AWS provider stops list/destroy_instance from printing another
-        # provider's leftover AWS runners as if they belonged to the active one.
-        {:error,
-         ErrorMessage.not_implemented(
-           "find_runners_from_ec2 is AWS-only (EC2 DescribeInstances) — not available for #{inspect(provider)}",
-           %{provider: provider}
-         )}
+      {:error,
+       ErrorMessage.not_implemented(
+         "find_runners_from_ec2 is AWS-only (EC2 DescribeInstances) — not available for #{inspect(provider)}",
+         %{provider: provider}
+       )}
     end
   end
 

--- a/lib/deploy_ex/ssh.ex
+++ b/lib/deploy_ex/ssh.ex
@@ -9,13 +9,7 @@ defmodule DeployEx.SSH do
     case prepare_identity_dir(pem_file_path) do
       {:ok, key_dir} ->
         try do
-          :ssh.connect(to_charlist(ip), port, maybe_add_ipv6(ip, [
-            {:user, to_charlist(user)},
-            {:user_dir, to_charlist(key_dir)},
-            {:auth_methods, ~c"publickey"},
-            {:user_interaction, false},
-            {:silently_accept_hosts, true}
-          ]))
+          :ssh.connect(to_charlist(ip), port, connect_options(ip, user, key_dir))
         after
           File.rm_rf(key_dir)
         end
@@ -23,6 +17,21 @@ defmodule DeployEx.SSH do
       {:error, _} = error ->
         error
     end
+  end
+
+  @doc """
+  `:ssh.connect/3` options for the given ip/user/key_dir. Pure and pinned directly by tests,
+  separated from the identity-file staging IO above so a regression to a hardcoded ssh user
+  shows up as a failing assertion on the options themselves.
+  """
+  def connect_options(ip, user, key_dir) do
+    maybe_add_ipv6(ip, [
+      {:user, to_charlist(user)},
+      {:user_dir, to_charlist(key_dir)},
+      {:auth_methods, ~c"publickey"},
+      {:user_interaction, false},
+      {:silently_accept_hosts, true}
+    ])
   end
 
   @doc false
@@ -72,8 +81,8 @@ defmodule DeployEx.SSH do
     end
   end
 
-  def run_command(ip, port \\ 22, pem_file_path, command) do
-    case connect_to_ssh(ip, port, pem_file_path) do
+  def run_command(ip, port \\ 22, pem_file_path, command, user \\ "admin") do
+    case connect_to_ssh(ip, port, pem_file_path, user) do
       {:error, reason} -> {:error, ErrorMessage.bad_gateway("couldn't connect over ssh: #{reason}")}
 
       {:ok, conn} ->

--- a/lib/deploy_ex/ssh.ex
+++ b/lib/deploy_ex/ssh.ex
@@ -81,7 +81,15 @@ defmodule DeployEx.SSH do
     end
   end
 
-  def run_command(ip, port \\ 22, pem_file_path, command, user \\ "admin") do
+  # opts-keyword rather than a second \\-defaulted positional (port \\ 22, ..., user \\ "admin")
+  # straddling the required pem_file_path/command args — two defaults on either side of
+  # required positions meant a 4-arg call like run_command(ip, pem, command, user) silently
+  # mis-bound user into the port slot instead of raising, since Elixir fills a short call's
+  # positions left-to-right rather than by which params happen to have defaults.
+  def run_command(ip, pem_file_path, command, opts \\ []) do
+    port = opts[:port] || 22
+    user = opts[:user] || "admin"
+
     case connect_to_ssh(ip, port, pem_file_path, user) do
       {:error, reason} -> {:error, ErrorMessage.bad_gateway("couldn't connect over ssh: #{reason}")}
 

--- a/lib/deploy_ex/tui/wizard/command_registry.ex
+++ b/lib/deploy_ex/tui/wizard/command_registry.ex
@@ -935,7 +935,8 @@ defmodule DeployEx.TUI.Wizard.CommandRegistry do
         input(:force, "Force", :boolean),
         input(:quiet, "Quiet", :boolean),
         input(:resource_group, "Resource group", :string),
-        input(:pem, "PEM file", :string)
+        input(:pem, "PEM file", :string),
+        input(:provider, "Cloud provider", :string)
       ]
     },
     %{
@@ -946,7 +947,8 @@ defmodule DeployEx.TUI.Wizard.CommandRegistry do
         input(:instance_id, "Instance ID", :string),
         input(:all, "All runners", :boolean),
         input(:force, "Force", :boolean),
-        input(:quiet, "Quiet", :boolean)
+        input(:quiet, "Quiet", :boolean),
+        input(:provider, "Cloud provider", :string)
       ]
     },
     %{
@@ -972,7 +974,8 @@ defmodule DeployEx.TUI.Wizard.CommandRegistry do
         input(:prometheus_url, "Prometheus URL", :string),
         input(:instance_id, "Instance ID", :string),
         input(:pem, "PEM file", :string),
-        input(:quiet, "Quiet", :boolean)
+        input(:quiet, "Quiet", :boolean),
+        input(:provider, "Cloud provider", :string)
       ]
     },
     %{
@@ -993,7 +996,8 @@ defmodule DeployEx.TUI.Wizard.CommandRegistry do
       category: "Load Test",
       inputs: [
         input(:json, "JSON output", :boolean),
-        input(:quiet, "Quiet", :boolean)
+        input(:quiet, "Quiet", :boolean),
+        input(:provider, "Cloud provider", :string)
       ]
     },
     %{
@@ -1009,7 +1013,8 @@ defmodule DeployEx.TUI.Wizard.CommandRegistry do
         input(:script, "Script path", :string, description: "Path to a specific script (default: all scripts for the app)"),
         input(:instance_id, "Instance ID", :string),
         input(:pem, "PEM file", :string),
-        input(:quiet, "Quiet", :boolean)
+        input(:quiet, "Quiet", :boolean),
+        input(:provider, "Cloud provider", :string)
       ]
     }
   ]

--- a/lib/mix/deploy_ex_helpers.ex
+++ b/lib/mix/deploy_ex_helpers.ex
@@ -213,7 +213,7 @@ defmodule DeployExHelpers do
         |> prompt_for_instance_choice(true)
         |> Enum.map(fn ip_address ->
           Mix.shell().info([:yellow, "Running '#{command}' on #{ip_address}"])
-          DeployEx.SSH.run_command(ip_address, opts[:port] || 22, pem_rsa_path, command)
+          DeployEx.SSH.run_command(ip_address, pem_rsa_path, command, port: opts[:port] || 22)
         end)
         |> DeployEx.Utils.reduce_status_tuples
 
@@ -241,7 +241,7 @@ defmodule DeployExHelpers do
         |> Enum.reduce_while(:ok, fn instance_ip, :ok ->
           Mix.shell().info([:yellow, "Running #{command} on #{instance_ip}"])
 
-          case DeployEx.SSH.run_command(instance_ip, opts[:port] || 22, pem_rsa_path, command) do
+          case DeployEx.SSH.run_command(instance_ip, pem_rsa_path, command, port: opts[:port] || 22) do
             {:ok, _} -> {:cont, :ok}
             {:error, _} = error -> {:halt, error}
           end

--- a/lib/mix/deploy_ex_helpers.ex
+++ b/lib/mix/deploy_ex_helpers.ex
@@ -35,6 +35,24 @@ defmodule DeployExHelpers do
     end
   end
 
+  @doc """
+  Validates and converts a parsed `--provider` CLI flag from string to atom in place.
+
+  `OptionParser.parse!/2` silently accepts any string for a `:string`-typed switch — an
+  unrecognized `--provider oci` would otherwise reach `DeployEx.Cloud.active_provider/1` as the
+  binary `"oci"` (not the atom `:oci`), which resolves through the "provider must be an atom"
+  fallback and runs against whatever the default provider is instead of erroring. Raises
+  `Mix.Error` (the standard task-failure signal `Mix.raise/1` produces) naming the bad value.
+  """
+  @spec parse_provider_opt!(keyword()) :: keyword()
+  def parse_provider_opt!(opts) do
+    case DeployEx.Cloud.parse_provider(opts[:provider]) do
+      {:ok, nil} -> opts
+      {:ok, provider} -> Keyword.put(opts, :provider, provider)
+      {:error, error} -> Mix.raise(ErrorMessage.to_string(error))
+    end
+  end
+
   def priv_folder(priv_subdirectory) do
     priv_path = :deploy_ex |> :code.priv_dir() |> Path.join(priv_subdirectory)
 

--- a/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
@@ -168,7 +168,8 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
          ),
          {:ok, :saved} <- DeployEx.K6Runner.save_state(runner, opts),
          :ok <- announce_instance_created(runner, opts),
-         :ok <- DeployEx.AwsMachine.wait_for_started([runner.instance_id]),
+         {:ok, machine} <- DeployEx.Cloud.capability(:machine, opts),
+         :ok <- machine.await_running([runner.instance_id], opts),
          {:ok, verified} <- verify_created_runner(runner, opts) do
       if !opts[:quiet] do
         Mix.shell().info([:green, "  ✓ ", :reset, "Instance running"])
@@ -238,9 +239,9 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
       Mix.shell().info([:faint, "Gathering infrastructure..."])
     end
 
-    DeployEx.AwsInfrastructure.gather_infrastructure(
-      Keyword.take(opts, [:resource_group])
-    )
+    with {:ok, infrastructure} <- DeployEx.Cloud.capability(:infrastructure, opts) do
+      infrastructure.gather_infrastructure(Keyword.take(opts, [:resource_group]))
+    end
   end
 
   # SSH reachability wait (D7: honest failure — never claims ready after exhausting retries)

--- a/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
@@ -212,13 +212,14 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
 
   defp orphaned_runner_error(runner, opts, k6_runner_impl) do
     k6_runner_impl.save_state(runner, opts)
+    provider = DeployEx.Cloud.active_provider(opts)
 
     {:error, ErrorMessage.failed_dependency(
-      "k6 runner #{runner.instance_id} was created but AWS does not yet report it as running " <>
+      "k6 runner #{runner.instance_id} was created but #{inspect(provider)} does not yet report it as running " <>
         "(eventual consistency) — the instance and its billing still exist; check again with " <>
         "mix deploy_ex.load_test.list, or destroy it with: " <>
         "mix deploy_ex.load_test.destroy_instance --instance-id #{runner.instance_id}",
-      %{instance_id: runner.instance_id}
+      %{instance_id: runner.instance_id, provider: provider}
     )}
   end
 

--- a/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
@@ -51,17 +51,21 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
     end
   end
 
-  defp parse_args(args) do
-    OptionParser.parse!(args,
+  @doc false
+  def parse_args(args) do
+    {opts, extra_args} = OptionParser.parse!(args,
       aliases: [f: :force, q: :quiet],
       switches: [
         instance_type: :string,
         force: :boolean,
         quiet: :boolean,
         resource_group: :string,
-        pem: :string
+        pem: :string,
+        provider: :string
       ]
     )
+
+    {DeployExHelpers.parse_provider_opt!(opts), extra_args}
   end
 
   defp maybe_reuse_or_create(opts) do

--- a/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
@@ -239,14 +239,28 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
     DeployEx.Terraform.find_pem_file(@terraform_default_path, opts[:pem])
   end
 
-  defp gather_infrastructure(opts) do
+  # Whitelisted to the keys a provider's gather_infrastructure/1 legitimately needs, not
+  # forwarded whole — mirrors the same reasoning as AwsMachine's request_fn whitelist
+  # (LT-OCI review-fix G1): :resource_group is AWS's own key, :pem lets OCI's find_key_pair
+  # honor a user's --pem override instead of always falling back to a directory glob, and
+  # :run_fn is the test injection seam (unused live; OCI's discovery is config-driven and
+  # never shells out, but the seam still needs to reach a provider that later does).
+  @doc false
+  def gather_infrastructure(opts) do
     if !opts[:quiet] do
       Mix.shell().info([:faint, "Gathering infrastructure..."])
     end
 
     with {:ok, infrastructure} <- DeployEx.Cloud.capability(:infrastructure, opts) do
-      infrastructure.gather_infrastructure(Keyword.take(opts, [:resource_group]))
+      infrastructure.gather_infrastructure(Keyword.take(opts, [:resource_group, :pem, :run_fn] ++ oci_setting_keys(opts)))
     end
+  end
+
+  # oci_* keys carry the OCI CLI's opts-first config overrides (DeployEx.Cloud.OciCli.setting/2)
+  # — Keyword.take/2 only needs their NAMES, so this just filters opts down to that shape
+  # without hardcoding the specific oci_subnet_id/oci_base_image/... list here twice.
+  defp oci_setting_keys(opts) do
+    opts |> Keyword.keys() |> Enum.filter(&String.starts_with?(Atom.to_string(&1), "oci_"))
   end
 
   # SSH reachability wait (D7: honest failure — never claims ready after exhausting retries)

--- a/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
@@ -310,7 +310,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
       Mix.shell().info([:faint, "Waiting for k6 setup to complete on ", :reset, :cyan, ip, :reset, :faint, "..."])
     end
 
-    check_fn = opts[:check_fn] || (&default_k6_ready?/2)
+    check_fn = opts[:check_fn] || (&default_k6_ready?(&1, &2, opts))
     sleep_fn = opts[:sleep_fn] || (&Process.sleep/1)
     retries = opts[:setup_wait_retries] || @setup_wait_retries
 
@@ -344,8 +344,8 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
     end
   end
 
-  defp default_k6_ready?(ip, pem_file) do
-    case DeployEx.SSH.run_command(ip, 22, pem_file, "k6 version") do
+  defp default_k6_ready?(ip, pem_file, opts) do
+    case DeployEx.SSH.run_command(ip, 22, pem_file, "k6 version", DeployEx.Cloud.ssh_user(opts)) do
       {:ok, _output} -> true
       _ -> false
     end

--- a/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.create_instance.ex
@@ -78,7 +78,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
         if opts[:force] do
           replace_runners(runners, opts)
         else
-          case DeployEx.K6Runner.verify_instance_exists(runner) do
+          case DeployEx.K6Runner.verify_instance_exists(runner, opts) do
             {:ok, verified} when not is_nil(verified) ->
               reuse_existing_runner(verified, opts)
 
@@ -350,7 +350,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstance do
   end
 
   defp default_k6_ready?(ip, pem_file, opts) do
-    case DeployEx.SSH.run_command(ip, 22, pem_file, "k6 version", DeployEx.Cloud.ssh_user(opts)) do
+    case DeployEx.SSH.run_command(ip, pem_file, "k6 version", user: DeployEx.Cloud.ssh_user(opts)) do
       {:ok, _output} -> true
       _ -> false
     end

--- a/lib/mix/tasks/deploy_ex.load_test.destroy_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.destroy_instance.ex
@@ -82,15 +82,18 @@ defmodule Mix.Tasks.DeployEx.LoadTest.DestroyInstance do
   def ambiguous_scope_error(_runners, _opts), do: :ok
 
   defp parse_args(args) do
-    OptionParser.parse!(args,
+    {opts, extra_args} = OptionParser.parse!(args,
       aliases: [i: :instance_id, f: :force, q: :quiet],
       switches: [
         instance_id: :string,
         all: :boolean,
         force: :boolean,
-        quiet: :boolean
+        quiet: :boolean,
+        provider: :string
       ]
     )
+
+    {DeployExHelpers.parse_provider_opt!(opts), extra_args}
   end
 
   defp find_runners_to_destroy(opts) do

--- a/lib/mix/tasks/deploy_ex.load_test.destroy_instance.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.destroy_instance.ex
@@ -102,7 +102,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.DestroyInstance do
         runners
         |> maybe_filter_by_instance_id(opts[:instance_id])
         |> Enum.map(fn runner ->
-          case DeployEx.K6Runner.verify_instance_exists(runner) do
+          case DeployEx.K6Runner.verify_instance_exists(runner, opts) do
             {:ok, verified} when not is_nil(verified) -> verified
             _ -> runner
           end

--- a/lib/mix/tasks/deploy_ex.load_test.exec.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.exec.ex
@@ -111,7 +111,9 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
 
   defdelegate resolve_runner(opts, k6_runner_impl \\ DeployEx.K6Runner), to: DeployEx.K6Runner
 
-  def resolve_prometheus_url(opts, discover_fn \\ &discover_prometheus_ip/0) do
+  def resolve_prometheus_url(opts, discover_fn \\ nil) do
+    discover_fn = discover_fn || fn -> discover_prometheus_ip(opts) end
+
     case opts[:prometheus_url] do
       url when is_binary(url) -> {:ok, url}
       _ -> resolve_discovered_prometheus_url(discover_fn)
@@ -125,9 +127,10 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
     end
   end
 
-  defp discover_prometheus_ip do
-    with {:ok, machine} <- DeployEx.Cloud.capability(:machine) do
-      case machine.list_instances([@prometheus_monitoring_tag], []) do
+  @doc false
+  def discover_prometheus_ip(opts \\ []) do
+    with {:ok, machine} <- DeployEx.Cloud.capability(:machine, opts) do
+      case machine.list_instances([@prometheus_monitoring_tag], opts) do
         {:ok, instances} -> find_running_prometheus_ip(instances)
         error -> error
       end

--- a/lib/mix/tasks/deploy_ex.load_test.exec.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.exec.ex
@@ -76,10 +76,10 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
           ])
         end
 
-        with :ok <- preflight_k6(ip, pem_file) do
+        with :ok <- preflight_k6(ip, pem_file, opts) do
           command = build_k6_command(script, prometheus_url, target_url)
 
-          case run_k6_via_ssh(ip, pem_file, command) do
+          case run_k6_via_ssh(ip, pem_file, command, opts) do
             :ok -> :ok
             {:error, reason} -> Mix.raise(reason)
           end
@@ -123,23 +123,31 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
   end
 
   defp discover_prometheus_ip do
-    case DeployEx.AwsMachine.find_instances_by_tags([@prometheus_monitoring_tag]) do
-      {:ok, instances} -> find_running_prometheus_ip(instances)
-      error -> error
+    with {:ok, machine} <- DeployEx.Cloud.capability(:machine) do
+      case machine.list_instances([@prometheus_monitoring_tag], []) do
+        {:ok, instances} -> find_running_prometheus_ip(instances)
+        error -> error
+      end
     end
   end
 
   defp find_running_prometheus_ip(instances) do
     case Enum.find(instances, &running_instance?/1) do
       nil -> {:error, ErrorMessage.not_found("no running prometheus node found")}
-      instance -> {:ok, instance["privateIpAddress"]}
+      instance -> {:ok, instance.private_ip}
     end
   end
 
-  defp running_instance?(instance), do: get_in(instance, ["instanceState", "name"]) === "running"
+  defp running_instance?(instance), do: instance.state === "running"
 
-  defp preflight_k6(ip, pem_file) do
-    case run_ssh_command(ip, pem_file, "k6 version") do
+  @doc """
+  SSH `user@host` target for a runner, resolved through `DeployEx.Cloud.ssh_user/1` so a
+  non-AWS provider's default user (e.g. OCI's `ubuntu`) reaches these SSH transports.
+  """
+  def ssh_target(ip, opts \\ []), do: "#{DeployEx.Cloud.ssh_user(opts)}@#{ip}"
+
+  defp preflight_k6(ip, pem_file, opts) do
+    case run_ssh_command(ip, pem_file, "k6 version", opts) do
       {:ok, _output} ->
         :ok
 
@@ -153,14 +161,14 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
 
   # SSH transport shell-out — dev-tooling exemption (spawns the ssh binary, no pure
   # logic to unit test; behavior is pinned by run_k6_via_ssh's Port-based sibling below).
-  defp run_ssh_command(ip, pem_file, command) do
+  defp run_ssh_command(ip, pem_file, command, opts) do
     abs_pem = Path.expand(pem_file)
 
     case System.cmd("ssh", [
       "-i", abs_pem,
       "-o", "StrictHostKeyChecking=no",
       "-o", "UserKnownHostsFile=/dev/null",
-      "admin@#{ip}",
+      ssh_target(ip, opts),
       command
     ], stderr_to_stdout: true) do
       {output, 0} -> {:ok, output}
@@ -188,7 +196,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
   defp env_var_prefix([]), do: ""
   defp env_var_prefix(env_vars), do: "#{Enum.join(env_vars, " ")} "
 
-  defp run_k6_via_ssh(ip, pem_file, command) do
+  defp run_k6_via_ssh(ip, pem_file, command, opts) do
     abs_pem = Path.expand(pem_file)
 
     port = Port.open({:spawn_executable, System.find_executable("ssh")}, [
@@ -199,7 +207,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
         "-i", abs_pem,
         "-o", "StrictHostKeyChecking=no",
         "-o", "UserKnownHostsFile=/dev/null",
-        "admin@#{ip}",
+        ssh_target(ip, opts),
         "sudo #{command}"
       ]
     ])

--- a/lib/mix/tasks/deploy_ex.load_test.exec.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.exec.ex
@@ -146,6 +146,22 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
   """
   def ssh_target(ip, opts \\ []), do: "#{DeployEx.Cloud.ssh_user(opts)}@#{ip}"
 
+  @doc """
+  Argv for the `ssh` binary, shared by both SSH transports below (`System.cmd` preflight and
+  the `Port.open` k6 run). Pure and pinned directly by tests — mirrors `build_k6_command/3` —
+  so a regression to a hardcoded ssh user shows up as a failing assertion on the argv itself,
+  not just on the `ssh_target/2` helper that could silently go unused at a call site.
+  """
+  def ssh_args(ip, pem_file, command, opts \\ []) do
+    [
+      "-i", Path.expand(pem_file),
+      "-o", "StrictHostKeyChecking=no",
+      "-o", "UserKnownHostsFile=/dev/null",
+      ssh_target(ip, opts),
+      command
+    ]
+  end
+
   defp preflight_k6(ip, pem_file, opts) do
     case run_ssh_command(ip, pem_file, "k6 version", opts) do
       {:ok, _output} ->
@@ -162,15 +178,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
   # SSH transport shell-out — dev-tooling exemption (spawns the ssh binary, no pure
   # logic to unit test; behavior is pinned by run_k6_via_ssh's Port-based sibling below).
   defp run_ssh_command(ip, pem_file, command, opts) do
-    abs_pem = Path.expand(pem_file)
-
-    case System.cmd("ssh", [
-      "-i", abs_pem,
-      "-o", "StrictHostKeyChecking=no",
-      "-o", "UserKnownHostsFile=/dev/null",
-      ssh_target(ip, opts),
-      command
-    ], stderr_to_stdout: true) do
+    case System.cmd("ssh", ssh_args(ip, pem_file, command, opts), stderr_to_stdout: true) do
       {output, 0} -> {:ok, output}
       {output, _code} -> {:error, output}
     end
@@ -197,19 +205,11 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
   defp env_var_prefix(env_vars), do: "#{Enum.join(env_vars, " ")} "
 
   defp run_k6_via_ssh(ip, pem_file, command, opts) do
-    abs_pem = Path.expand(pem_file)
-
     port = Port.open({:spawn_executable, System.find_executable("ssh")}, [
       :binary,
       :exit_status,
       :stderr_to_stdout,
-      args: [
-        "-i", abs_pem,
-        "-o", "StrictHostKeyChecking=no",
-        "-o", "UserKnownHostsFile=/dev/null",
-        ssh_target(ip, opts),
-        "sudo #{command}"
-      ]
+      args: ssh_args(ip, pem_file, "sudo #{command}", opts)
     ])
 
     stream_output(port)

--- a/lib/mix/tasks/deploy_ex.load_test.exec.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.exec.ex
@@ -146,18 +146,16 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
 
   defp running_instance?(instance), do: instance.state === "running"
 
-  @doc """
-  SSH `user@host` target for a runner, resolved through `DeployEx.Cloud.ssh_user/1` so a
-  non-AWS provider's default user (e.g. OCI's `ubuntu`) reaches these SSH transports.
-  """
+  # SSH `user@host` target for a runner, resolved through `DeployEx.Cloud.ssh_user/1` so a
+  # non-AWS provider's default user (e.g. OCI's `ubuntu`) reaches these SSH transports.
+  @doc false
   def ssh_target(ip, opts \\ []), do: "#{DeployEx.Cloud.ssh_user(opts)}@#{ip}"
 
-  @doc """
-  Argv for the `ssh` binary, shared by both SSH transports below (`System.cmd` preflight and
-  the `Port.open` k6 run). Pure and pinned directly by tests — mirrors `build_k6_command/3` —
-  so a regression to a hardcoded ssh user shows up as a failing assertion on the argv itself,
-  not just on the `ssh_target/2` helper that could silently go unused at a call site.
-  """
+  # Argv for the `ssh` binary, shared by both SSH transports below (`System.cmd` preflight and
+  # the `Port.open` k6 run). Pure and pinned directly by tests — mirrors `build_k6_command/3` —
+  # so a regression to a hardcoded ssh user shows up as a failing assertion on the argv itself,
+  # not just on the `ssh_target/2` helper that could silently go unused at a call site.
+  @doc false
   def ssh_args(ip, pem_file, command, opts \\ []) do
     [
       "-i", Path.expand(pem_file),

--- a/lib/mix/tasks/deploy_ex.load_test.exec.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.exec.ex
@@ -93,7 +93,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
   end
 
   defp parse_args(args) do
-    OptionParser.parse!(args,
+    {opts, extra_args} = OptionParser.parse!(args,
       aliases: [i: :instance_id, q: :quiet],
       switches: [
         script: :string,
@@ -101,9 +101,12 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
         prometheus_url: :string,
         instance_id: :string,
         pem: :string,
-        quiet: :boolean
+        quiet: :boolean,
+        provider: :string
       ]
     )
+
+    {DeployExHelpers.parse_provider_opt!(opts), extra_args}
   end
 
   defdelegate resolve_runner(opts, k6_runner_impl \\ DeployEx.K6Runner), to: DeployEx.K6Runner

--- a/lib/mix/tasks/deploy_ex.load_test.list.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.list.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.List do
     case DeployEx.K6Runner.fetch_all_runners(opts) do
       {:ok, runners} ->
         verified = Enum.map(runners, fn runner ->
-          case DeployEx.K6Runner.verify_instance_exists(runner) do
+          case DeployEx.K6Runner.verify_instance_exists(runner, opts) do
             {:ok, verified} when not is_nil(verified) -> verified
             _ -> nil
           end

--- a/lib/mix/tasks/deploy_ex.load_test.list.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.list.ex
@@ -36,11 +36,12 @@ defmodule Mix.Tasks.DeployEx.LoadTest.List do
       aliases: [q: :quiet],
       switches: [
         json: :boolean,
-        quiet: :boolean
+        quiet: :boolean,
+        provider: :string
       ]
     )
 
-    opts
+    DeployExHelpers.parse_provider_opt!(opts)
   end
 
   defp list_runners(opts) do

--- a/lib/mix/tasks/deploy_ex.load_test.upload.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.upload.ex
@@ -116,17 +116,15 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Upload do
     end
   end
 
-  @doc """
-  `user@host:path` scp target for a runner, resolved through `DeployEx.Cloud.ssh_user/1` so a
-  non-AWS provider's default user (e.g. OCI's `ubuntu`) reaches this SSH transport.
-  """
+  # `user@host:path` scp target for a runner, resolved through `DeployEx.Cloud.ssh_user/1` so a
+  # non-AWS provider's default user (e.g. OCI's `ubuntu`) reaches this SSH transport.
+  @doc false
   def scp_target(ip, remote_path, opts \\ []), do: "#{DeployEx.Cloud.ssh_user(opts)}@#{ip}:#{remote_path}"
 
-  @doc """
-  Argv for the `scp` binary. Pure and pinned directly by tests — mirrors `Exec.ssh_args/4` —
-  so a regression to a hardcoded ssh user shows up as a failing assertion on the argv itself,
-  not just on the `scp_target/3` helper that could silently go unused at the call site.
-  """
+  # Argv for the `scp` binary. Pure and pinned directly by tests — mirrors `Exec.ssh_args/4` —
+  # so a regression to a hardcoded ssh user shows up as a failing assertion on the argv itself,
+  # not just on the `scp_target/3` helper that could silently go unused at the call site.
+  @doc false
   def scp_args(pem_file, script_path, ip, remote_path, opts \\ []) do
     [
       "-i", Path.expand(pem_file),

--- a/lib/mix/tasks/deploy_ex.load_test.upload.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.upload.ex
@@ -68,15 +68,18 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Upload do
   end
 
   defp parse_args(args) do
-    OptionParser.parse!(args,
+    {opts, extra_args} = OptionParser.parse!(args,
       aliases: [i: :instance_id, q: :quiet],
       switches: [
         script: :string,
         instance_id: :string,
         pem: :string,
-        quiet: :boolean
+        quiet: :boolean,
+        provider: :string
       ]
     )
+
+    {DeployExHelpers.parse_provider_opt!(opts), extra_args}
   end
 
   defdelegate resolve_runner(opts, k6_runner_impl \\ DeployEx.K6Runner), to: DeployEx.K6Runner

--- a/lib/mix/tasks/deploy_ex.load_test.upload.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.upload.ex
@@ -119,6 +119,21 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Upload do
   """
   def scp_target(ip, remote_path, opts \\ []), do: "#{DeployEx.Cloud.ssh_user(opts)}@#{ip}:#{remote_path}"
 
+  @doc """
+  Argv for the `scp` binary. Pure and pinned directly by tests — mirrors `Exec.ssh_args/4` —
+  so a regression to a hardcoded ssh user shows up as a failing assertion on the argv itself,
+  not just on the `scp_target/3` helper that could silently go unused at the call site.
+  """
+  def scp_args(pem_file, script_path, ip, remote_path, opts \\ []) do
+    [
+      "-i", Path.expand(pem_file),
+      "-o", "StrictHostKeyChecking=no",
+      "-o", "UserKnownHostsFile=/dev/null",
+      script_path,
+      scp_target(ip, remote_path, opts)
+    ]
+  end
+
   defp upload_script(script_path, ip, pem_file, opts) do
     filename = Path.basename(script_path)
     remote_path = "/srv/k6/scripts/#{filename}"
@@ -127,15 +142,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Upload do
       Mix.shell().info([:faint, "Uploading ", :reset, filename, :faint, " → ", :reset, remote_path])
     end
 
-    abs_pem = Path.expand(pem_file)
-
-    case System.cmd("scp", [
-      "-i", abs_pem,
-      "-o", "StrictHostKeyChecking=no",
-      "-o", "UserKnownHostsFile=/dev/null",
-      script_path,
-      scp_target(ip, remote_path, opts)
-    ], stderr_to_stdout: true) do
+    case System.cmd("scp", scp_args(pem_file, script_path, ip, remote_path, opts), stderr_to_stdout: true) do
       {_, 0} ->
         unless opts[:quiet] do
           Mix.shell().info([:green, "  ✓ ", :reset, filename])

--- a/lib/mix/tasks/deploy_ex.load_test.upload.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.upload.ex
@@ -113,6 +113,12 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Upload do
     end
   end
 
+  @doc """
+  `user@host:path` scp target for a runner, resolved through `DeployEx.Cloud.ssh_user/1` so a
+  non-AWS provider's default user (e.g. OCI's `ubuntu`) reaches this SSH transport.
+  """
+  def scp_target(ip, remote_path, opts \\ []), do: "#{DeployEx.Cloud.ssh_user(opts)}@#{ip}:#{remote_path}"
+
   defp upload_script(script_path, ip, pem_file, opts) do
     filename = Path.basename(script_path)
     remote_path = "/srv/k6/scripts/#{filename}"
@@ -128,7 +134,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Upload do
       "-o", "StrictHostKeyChecking=no",
       "-o", "UserKnownHostsFile=/dev/null",
       script_path,
-      "admin@#{ip}:#{remote_path}"
+      scp_target(ip, remote_path, opts)
     ], stderr_to_stdout: true) do
       {_, 0} ->
         unless opts[:quiet] do

--- a/test/deploy_ex/aws_machine_test.exs
+++ b/test/deploy_ex/aws_machine_test.exs
@@ -155,6 +155,20 @@ defmodule DeployEx.AwsMachineTest do
              }
     end
 
+    test "nil instance_type in the spec falls back to t3.small — AwsMachine owns its own default (LT-OCI S2)" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: run_instances_response("i-nil-type")}}
+      end
+
+      spec = %{neutral_spec() | instance_type: nil}
+
+      AwsMachine.run_instance(spec, request_fn: request_fn)
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{params: params}}
+      assert params["InstanceType"] === "t3.small"
+    end
+
     test "requests against the given region rather than the configured default" do
       request_fn = fn request, config ->
         send(self(), {:ec2_request, request, config})

--- a/test/deploy_ex/aws_machine_test.exs
+++ b/test/deploy_ex/aws_machine_test.exs
@@ -38,6 +38,63 @@ defmodule DeployEx.AwsMachineTest do
       assert {:error, %ErrorMessage{code: :not_found}} =
                AwsMachine.describe_instance("i-missing", request_fn: request_fn)
     end
+
+    test "does NOT forward arbitrary caller opts into the DescribeInstances request params (G1 credential-leak guard)" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: describe_instance_response("i-1", "running")}}
+      end
+
+      # A caller's whole opts keyword list often carries a pem file PATH (--pem), the resolved
+      # :provider, --quiet, etc. Only :request_fn is a real seam here — everything else must be
+      # whitelisted away before it reaches ExAws.EC2.describe_instances/1, or it becomes a real
+      # EC2 API query parameter (e.g. "Pem" => "/secret/path/key.pem") that reaches AWS and
+      # CloudTrail.
+      AwsMachine.describe_instance("i-1",
+        request_fn: request_fn,
+        pem: "/secret/path/key.pem",
+        quiet: true,
+        provider: :oci
+      )
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{params: params}}
+
+      refute Map.has_key?(params, "Pem")
+      refute Map.has_key?(params, "Quiet")
+      refute Map.has_key?(params, "Provider")
+
+      assert params === %{"Action" => "DescribeInstances", "Version" => "2016-11-15"}
+    end
+  end
+
+  describe "find_instances_by_tags/2 — request_fn seam + no opts leak (LT-OCI review-fix cycle 3)" do
+    test "routes the tag-filter query through the injected request_fn" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: "<DescribeInstancesResponse><reservationSet/></DescribeInstancesResponse>"}}
+      end
+
+      assert {:ok, []} = AwsMachine.find_instances_by_tags([{"K6Runner", "true"}], request_fn: request_fn)
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{action: :describe_instances}}
+    end
+
+    test "does NOT forward arbitrary caller opts into the request params (same G1 leak class)" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: "<DescribeInstancesResponse><reservationSet/></DescribeInstancesResponse>"}}
+      end
+
+      AwsMachine.find_instances_by_tags([{"K6Runner", "true"}],
+        request_fn: request_fn,
+        pem: "/secret/path/key.pem",
+        quiet: true
+      )
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{params: params}}
+      refute Map.has_key?(params, "Pem")
+      refute Map.has_key?(params, "Quiet")
+    end
   end
 
   describe "run_instance/2 — neutral spec to EC2 RunInstances params (LT-OCI S1)" do

--- a/test/deploy_ex/aws_machine_test.exs
+++ b/test/deploy_ex/aws_machine_test.exs
@@ -1,0 +1,151 @@
+defmodule DeployEx.AwsMachineTest do
+  @moduledoc """
+  Behavioural tests for the LT-OCI S1 seam additions to `DeployEx.AwsMachine`:
+  `run_instance/2` (neutral spec -> EC2 RunInstances params) and `await_running/2`
+  (wraps `wait_for_started/3` without reimplementing its poll loop).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias DeployEx.AwsMachine
+  alias DeployEx.Cloud.Instance
+
+  describe "run_instance/2 — neutral spec to EC2 RunInstances params (LT-OCI S1)" do
+    defp neutral_spec do
+      %{
+        name: "K6-Runner-test-1",
+        instance_type: "t3.small",
+        user_data: "#!/bin/bash\necho hi\n",
+        tags: [{:Name, "K6-Runner-test-1"}, {:Group, "My Backend"}, {:K6Runner, "true"}],
+        network: %{
+          key_name: "my-key",
+          subnet_id: "subnet-123",
+          security_group_id: "sg-123",
+          ami_id: "ami-123",
+          iam_instance_profile: "profile-name"
+        }
+      }
+    end
+
+    defp run_instances_response(instance_id) do
+      "<RunInstancesResponse><instancesSet><item>" <>
+        "<instanceId>#{instance_id}</instanceId>" <>
+        "</item></instancesSet></RunInstancesResponse>"
+    end
+
+    test "translates the neutral spec into the exact EC2 params AWS expects" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: run_instances_response("i-abc123")}}
+      end
+
+      assert {:ok, %Instance{id: "i-abc123"}} =
+               AwsMachine.run_instance(neutral_spec(), request_fn: request_fn)
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{params: params}}
+
+      assert params === %{
+               "Action" => "RunInstances",
+               "IamInstanceProfile.Name" => "profile-name",
+               "ImageId" => "ami-123",
+               "InstanceType" => "t3.small",
+               "KeyName" => "my-key",
+               "MaxCount" => 1,
+               "MinCount" => 1,
+               "NetworkInterface.1.AssociatePublicIpAddress" => "true",
+               "NetworkInterface.1.DeviceIndex" => "0",
+               "NetworkInterface.1.SecurityGroupId.1" => "sg-123",
+               "NetworkInterface.1.SubnetId" => "subnet-123",
+               "TagSpecification.1.ResourceType" => "instance",
+               "TagSpecification.1.Tag.1.Key" => "Name",
+               "TagSpecification.1.Tag.1.Value" => "K6-Runner-test-1",
+               "TagSpecification.1.Tag.2.Key" => "Group",
+               "TagSpecification.1.Tag.2.Value" => "My Backend",
+               "TagSpecification.1.Tag.3.Key" => "K6Runner",
+               "TagSpecification.1.Tag.3.Value" => "true",
+               "UserData" => Base.encode64(neutral_spec().user_data),
+               "Version" => "2016-11-15"
+             }
+    end
+
+    test "requests against the given region rather than the configured default" do
+      request_fn = fn request, config ->
+        send(self(), {:ec2_request, request, config})
+        {:ok, %{body: run_instances_response("i-region-test")}}
+      end
+
+      AwsMachine.run_instance(neutral_spec(), request_fn: request_fn, region: "eu-west-1")
+
+      assert_received {:ec2_request, _request, config}
+      assert config[:region] === "eu-west-1"
+    end
+
+    test "maps an AWS http error to an ErrorMessage instead of raising" do
+      request_fn = fn _request, _config ->
+        {:error, {:http_error, 400, %{body: "boom"}}}
+      end
+
+      assert {:error, %ErrorMessage{code: :bad_request}} =
+               AwsMachine.run_instance(neutral_spec(), request_fn: request_fn)
+    end
+  end
+
+  describe "terminate_instance/2 — LT-OCI S1" do
+    test "sends the exact EC2 TerminateInstances params for the given instance id" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: "<TerminateInstancesResponse></TerminateInstancesResponse>"}}
+      end
+
+      assert :ok = AwsMachine.terminate_instance("i-terminate-1", request_fn: request_fn)
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{action: :terminate_instances, params: params}}
+      assert params["InstanceId.1"] === "i-terminate-1"
+    end
+
+    test "maps an AWS http error to an ErrorMessage instead of raising" do
+      request_fn = fn _request, _config ->
+        {:error, {:http_error, 400, %{body: "boom"}}}
+      end
+
+      assert {:error, %ErrorMessage{code: :bad_request}} =
+               AwsMachine.terminate_instance("i-terminate-2", request_fn: request_fn)
+    end
+  end
+
+  describe "await_running/2 — wraps wait_for_started (LT-OCI S1)" do
+    test "delegates to the injected wait function with the resolved region and retries" do
+      wait_fn = fn region, instance_ids, retries ->
+        send(self(), {:waited, region, instance_ids, retries})
+        :ok
+      end
+
+      assert AwsMachine.await_running(["i-1"],
+               region: "us-east-1",
+               retries: 3,
+               wait_for_started_fn: wait_fn
+             ) === :ok
+
+      assert_received {:waited, "us-east-1", ["i-1"], 3}
+    end
+
+    test "defaults region to the configured region and retries to 10 when opts omit them" do
+      wait_fn = fn region, instance_ids, retries ->
+        send(self(), {:waited, region, instance_ids, retries})
+        :ok
+      end
+
+      AwsMachine.await_running(["i-1"], wait_for_started_fn: wait_fn)
+
+      assert_received {:waited, region, ["i-1"], 10}
+      assert region === DeployEx.Config.aws_region()
+    end
+
+    test "propagates an error from the wait function unchanged" do
+      error = ErrorMessage.failed_dependency("instance never started", %{instance_ids: ["i-1"]})
+      wait_fn = fn _region, _instance_ids, _retries -> {:error, error} end
+
+      assert AwsMachine.await_running(["i-1"], wait_for_started_fn: wait_fn) === {:error, error}
+    end
+  end
+end

--- a/test/deploy_ex/aws_machine_test.exs
+++ b/test/deploy_ex/aws_machine_test.exs
@@ -10,6 +10,36 @@ defmodule DeployEx.AwsMachineTest do
   alias DeployEx.AwsMachine
   alias DeployEx.Cloud.Instance
 
+  describe "describe_instance/2 — request_fn seam (LT-OCI review-fix)" do
+    defp describe_instance_response(instance_id, state) do
+      "<DescribeInstancesResponse><reservationSet><item><instancesSet><item>" <>
+        "<instanceId>#{instance_id}</instanceId>" <>
+        "<instanceState><name>#{state}</name></instanceState>" <>
+        "</item></instancesSet></item></reservationSet></DescribeInstancesResponse>"
+    end
+
+    test "routes the DescribeInstances call through the injected request_fn, not the real ExAws.request" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: describe_instance_response("i-1", "running")}}
+      end
+
+      assert {:ok, %Instance{id: "i-1", state: "running"}} =
+               AwsMachine.describe_instance("i-1", request_fn: request_fn)
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{action: :describe_instances}}
+    end
+
+    test "returns a not_found error when no instance matches, without hitting the real network" do
+      request_fn = fn _request, _config ->
+        {:ok, %{body: "<DescribeInstancesResponse><reservationSet/></DescribeInstancesResponse>"}}
+      end
+
+      assert {:error, %ErrorMessage{code: :not_found}} =
+               AwsMachine.describe_instance("i-missing", request_fn: request_fn)
+    end
+  end
+
   describe "run_instance/2 — neutral spec to EC2 RunInstances params (LT-OCI S1)" do
     defp neutral_spec do
       %{

--- a/test/deploy_ex/aws_machine_test.exs
+++ b/test/deploy_ex/aws_machine_test.exs
@@ -215,6 +215,10 @@ defmodule DeployEx.AwsMachineTest do
   end
 
   describe "await_running/2 — wraps wait_for_started (LT-OCI S1)" do
+    test "an empty instance-id list is an error, not a vacuous :ok" do
+      assert {:error, %ErrorMessage{code: :bad_request}} = AwsMachine.await_running([], [])
+    end
+
     test "delegates to the injected wait function with the resolved region and retries" do
       wait_fn = fn region, instance_ids, retries ->
         send(self(), {:waited, region, instance_ids, retries})

--- a/test/deploy_ex/cloud/oci_cli_test.exs
+++ b/test/deploy_ex/cloud/oci_cli_test.exs
@@ -1,0 +1,68 @@
+defmodule DeployEx.Cloud.OciCliTest do
+  @moduledoc """
+  Behavioural tests for `DeployEx.Cloud.OciCli` — LT-OCI S2 review-fix (SECURITY).
+
+  `:auth`/`:profile`/`:region` interpolate directly into a shell command string
+  (`OCI_CLI_AUTH=<auth> ... --profile <profile> --region <region>`); every test here proves
+  the composed command quotes those values instead of executing a hostile payload — no test
+  in this file ever runs a real shell, only inspects the string `:run_fn` captures.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias DeployEx.Cloud.OciCli
+
+  defp capture_command(response \\ {:ok, "output"}) do
+    fn command, _cwd ->
+      send(self(), {:oci_command, command})
+      response
+    end
+  end
+
+  describe "build_command (via run/2) — shell injection guard" do
+    test "a hostile :auth setting is quoted, not executed as a second shell command" do
+      OciCli.run("os bucket list", oci_auth: "api_key; touch /tmp/PWNED", run_fn: capture_command())
+
+      assert_received {:oci_command, command}
+      assert command =~ "OCI_CLI_AUTH='api_key; touch /tmp/PWNED'"
+      refute command =~ ~r/OCI_CLI_AUTH=api_key;/
+    end
+
+    test "a hostile :profile setting is quoted, not executed" do
+      OciCli.run("os bucket list", oci_profile: "DEFAULT`touch /tmp/PWNED`", run_fn: capture_command())
+
+      assert_received {:oci_command, command}
+      assert command =~ "--profile 'DEFAULT`touch /tmp/PWNED`'"
+    end
+
+    test "a hostile :region setting is quoted, not executed" do
+      OciCli.run("os bucket list", oci_region: "us-phoenix-1 && touch /tmp/PWNED", run_fn: capture_command())
+
+      assert_received {:oci_command, command}
+      assert command =~ "--region 'us-phoenix-1 && touch /tmp/PWNED'"
+    end
+
+    test "a value containing a single quote is escaped, not left to break out of quoting" do
+      OciCli.run("os bucket list", oci_profile: "it's-a-profile", run_fn: capture_command())
+
+      assert_received {:oci_command, command}
+      assert command =~ "--profile 'it'\\''s-a-profile'"
+    end
+
+    test "the default auth (no override) is still quoted" do
+      OciCli.run("os bucket list", run_fn: capture_command())
+
+      assert_received {:oci_command, command}
+      assert command =~ "OCI_CLI_AUTH='api_key'"
+    end
+
+    test "well-behaved settings still produce a working command (no functional regression)" do
+      OciCli.run("os bucket list", oci_profile: "DEFAULT", oci_region: "us-phoenix-1", run_fn: capture_command())
+
+      assert_received {:oci_command, command}
+      assert command =~ "--profile 'DEFAULT'"
+      assert command =~ "--region 'us-phoenix-1'"
+      assert command =~ "oci os bucket list"
+    end
+  end
+end

--- a/test/deploy_ex/cloud/oci_infrastructure_test.exs
+++ b/test/deploy_ex/cloud/oci_infrastructure_test.exs
@@ -1,0 +1,72 @@
+defmodule DeployEx.Cloud.OciInfrastructureTest do
+  @moduledoc """
+  Behavioural tests for `DeployEx.Cloud.OciInfrastructure` — LT-OCI S2. Config-driven
+  ("discovery-lite"): every callback reads a value directly out of the `:oci` config
+  namespace (via `opts` overrides in these tests, matching `OciCli.setting/2`'s opts-first
+  precedence) rather than querying the tenancy, so nothing here needs a live OCI call.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias DeployEx.Cloud.OciInfrastructure
+
+  describe "find_network/1" do
+    test "honest not_implemented — OCI infra discovery this sprint is subnet/image only" do
+      assert {:error, %ErrorMessage{code: :not_implemented}} = OciInfrastructure.find_network([])
+    end
+  end
+
+  describe "find_subnet/1" do
+    test "resolves the configured subnet_id" do
+      assert {:ok, "ocid1.subnet.oc1..aaaa"} = OciInfrastructure.find_subnet(oci_subnet_id: "ocid1.subnet.oc1..aaaa")
+    end
+
+    test "errors loudly when unset rather than launching into a nil subnet" do
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} = OciInfrastructure.find_subnet([])
+      assert message =~ "subnet_id"
+    end
+  end
+
+  describe "find_image/1" do
+    test "resolves a configured string base_image directly as the image OCID" do
+      assert {:ok, "ocid1.image.oc1..aaaa"} =
+               OciInfrastructure.find_image(oci_base_image: "ocid1.image.oc1..aaaa")
+    end
+
+    test "errors loudly when unset" do
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} = OciInfrastructure.find_image([])
+      assert message =~ "base_image"
+    end
+
+    test "a keyword-list (per-app) base_image is honestly not_implemented this sprint" do
+      assert {:error, %ErrorMessage{code: :not_implemented}} =
+               OciInfrastructure.find_image(oci_base_image: [my_app: "ocid1.image.oc1..bbbb"])
+    end
+  end
+
+  describe "find_key_pair/2" do
+    test "an explicit :pem opt bypasses directory glob search entirely" do
+      assert {:ok, "/tmp/some-key.pem"} = OciInfrastructure.find_key_pair("my-project", pem: "/tmp/some-key.pem")
+    end
+  end
+
+  describe "find_instance_identity/1" do
+    test "returns {:ok, nil} — OCI instance principals use dynamic groups, not a per-launch identity string" do
+      assert {:ok, nil} = OciInfrastructure.find_instance_identity([])
+    end
+  end
+
+  describe "gather_infrastructure/1" do
+    test "bundles subnet_id, image_id and key_name from config" do
+      opts = [oci_subnet_id: "ocid1.subnet.oc1..aaaa", oci_base_image: "ocid1.image.oc1..aaaa", pem: "/tmp/key.pem"]
+
+      assert {:ok, %{subnet_id: "ocid1.subnet.oc1..aaaa", image_id: "ocid1.image.oc1..aaaa", key_name: "/tmp/key.pem"}} =
+               OciInfrastructure.gather_infrastructure(opts)
+    end
+
+    test "propagates the first missing piece as an error instead of a partial bundle" do
+      assert {:error, %ErrorMessage{code: :bad_request}} =
+               OciInfrastructure.gather_infrastructure(oci_base_image: "ocid1.image.oc1..aaaa", pem: "/tmp/key.pem")
+    end
+  end
+end

--- a/test/deploy_ex/cloud/oci_machine_test.exs
+++ b/test/deploy_ex/cloud/oci_machine_test.exs
@@ -1,0 +1,421 @@
+defmodule DeployEx.Cloud.OciMachineTest do
+  @moduledoc """
+  Behavioural tests for `DeployEx.Cloud.OciMachine` — LT-OCI S2. Every command goes through
+  `DeployEx.Cloud.OciCli.run/run_json`'s `:run_fn` injection seam, so no test makes a live
+  OCI call. Multi-key JSON payloads (freeform-tags, metadata) are decoded back out of the
+  captured command string rather than asserted as a literal substring, since Elixir map
+  iteration order is not a stable string to pin against.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias DeployEx.Cloud.Instance
+  alias DeployEx.Cloud.OciMachine
+
+  defp capture_command(response) do
+    fn command, _cwd ->
+      send(self(), {:oci_command, command})
+      response
+    end
+  end
+
+  defp flag_value(command, flag) do
+    case Regex.run(~r/#{Regex.escape(flag)} '((?:[^'\\]|\\.)*)'/, command) do
+      [_match, value] -> String.replace(value, "'\\''", "'")
+      nil -> nil
+    end
+  end
+
+  # Per-PID response queue for tests that need to return a different body on each successive
+  # run_fn call (e.g. await_running's poll loop) — process-dict based, matches the
+  # queue_responses/next_response pattern already used by k6_runner_test.exs's pagination
+  # tests, no Agent/ETS needed.
+  defp queue_responses(responses), do: Process.put(:oci_responses, responses)
+
+  defp next_response do
+    [head | rest] = Process.get(:oci_responses)
+    Process.put(:oci_responses, rest)
+    head
+  end
+
+  describe "list_instances/2" do
+    defp instance_list_response(instances) do
+      {:ok, Jason.encode!(%{"data" => instances})}
+    end
+
+    test "lists every instance in the compartment via oci compute instance list --all" do
+      run_fn = capture_command(instance_list_response([]))
+
+      assert {:ok, []} = OciMachine.list_instances([], oci_compartment_id: "ocid1.compartment..a", run_fn: run_fn)
+
+      assert_received {:oci_command, command}
+      assert command =~ "oci compute instance list"
+      assert flag_value(command, "--compartment-id") === "ocid1.compartment..a"
+      assert command =~ "--all"
+    end
+
+    test "requires compartment_id instead of listing the wrong compartment" do
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} = OciMachine.list_instances([], [])
+      assert message =~ "compartment_id"
+    end
+
+    test "filters client-side by exact tag match" do
+      matching = %{
+        "id" => "ocid1.instance..match",
+        "display-name" => "K6-Runner-1",
+        "lifecycle-state" => "RUNNING",
+        "freeform-tags" => %{"K6Runner" => "true"},
+        "time-created" => "2024-01-15T10:30:00.000Z"
+      }
+
+      not_matching = %{
+        "id" => "ocid1.instance..other",
+        "display-name" => "Other",
+        "lifecycle-state" => "RUNNING",
+        "freeform-tags" => %{"K6Runner" => "false"},
+        "time-created" => "2024-01-15T10:30:00.000Z"
+      }
+
+      run_fn = capture_command(instance_list_response([matching, not_matching]))
+
+      assert {:ok, [%Instance{id: "ocid1.instance..match"}]} =
+               OciMachine.list_instances([{"K6Runner", "true"}], oci_compartment_id: "ocid1.compartment..a", run_fn: run_fn)
+    end
+
+    test "filters client-side by a list-of-scalars matcher (any-of)" do
+      instances = [
+        %{"id" => "i-1", "freeform-tags" => %{"Group" => "a"}, "lifecycle-state" => "RUNNING"},
+        %{"id" => "i-2", "freeform-tags" => %{"Group" => "b"}, "lifecycle-state" => "RUNNING"},
+        %{"id" => "i-3", "freeform-tags" => %{"Group" => "c"}, "lifecycle-state" => "RUNNING"}
+      ]
+
+      run_fn = capture_command(instance_list_response(instances))
+
+      assert {:ok, matched} =
+               OciMachine.list_instances([{"Group", ["a", "b"]}], oci_compartment_id: "c", run_fn: run_fn)
+
+      assert Enum.map(matched, & &1.id) |> Enum.sort() === ["i-1", "i-2"]
+    end
+
+    test "filters client-side by a Regex matcher" do
+      instances = [
+        %{"id" => "i-1", "freeform-tags" => %{"Name" => "K6-Runner-prod-1"}, "lifecycle-state" => "RUNNING"},
+        %{"id" => "i-2", "freeform-tags" => %{"Name" => "Other-node"}, "lifecycle-state" => "RUNNING"}
+      ]
+
+      run_fn = capture_command(instance_list_response(instances))
+
+      assert {:ok, [%Instance{id: "i-1"}]} =
+               OciMachine.list_instances([{"Name", ~r/^K6-Runner/}], oci_compartment_id: "c", run_fn: run_fn)
+    end
+
+    test "an instance missing the filtered tag entirely does not match" do
+      instances = [%{"id" => "i-1", "freeform-tags" => %{}, "lifecycle-state" => "RUNNING"}]
+      run_fn = capture_command(instance_list_response(instances))
+
+      assert {:ok, []} = OciMachine.list_instances([{"K6Runner", "true"}], oci_compartment_id: "c", run_fn: run_fn)
+    end
+
+    test "an empty response (oci CLI prints nothing for zero matches) decodes to an empty list, not an error" do
+      run_fn = capture_command({:ok, ""})
+
+      assert {:ok, []} = OciMachine.list_instances([], oci_compartment_id: "c", run_fn: run_fn)
+    end
+  end
+
+  describe "describe_instance/2 + fetch_tags/2 + instance_address/1" do
+    defp instance_get_response(instance) do
+      {:ok, Jason.encode!(%{"data" => instance})}
+    end
+
+    defp vnic_list_response(vnics) do
+      {:ok, Jason.encode!(%{"data" => vnics})}
+    end
+
+    test "combines instance get + list-vnics into a normalized Instance" do
+      run_fn = fn command, _cwd ->
+        cond do
+          command =~ "instance get" ->
+            instance_get_response(%{
+              "id" => "ocid1.instance..a",
+              "display-name" => "K6-Runner-prod-1",
+              "lifecycle-state" => "RUNNING",
+              "freeform-tags" => %{"Name" => "K6-Runner-prod-1", "K6Runner" => "true"},
+              "time-created" => "2024-01-15T10:30:00.000Z"
+            })
+
+          command =~ "list-vnics" ->
+            vnic_list_response([%{"public-ip" => "1.2.3.4", "private-ip" => "10.0.0.5", "is-primary" => true}])
+        end
+      end
+
+      assert {:ok,
+              %Instance{
+                id: "ocid1.instance..a",
+                name: "K6-Runner-prod-1",
+                state: "RUNNING",
+                public_ip: "1.2.3.4",
+                private_ip: "10.0.0.5",
+                tags: %{"Name" => "K6-Runner-prod-1", "K6Runner" => "true"}
+              }} = OciMachine.describe_instance("ocid1.instance..a", run_fn: run_fn)
+    end
+
+    test "an instance with no vnic (still provisioning) has nil addresses, not a crash" do
+      run_fn = fn command, _cwd ->
+        cond do
+          command =~ "instance get" ->
+            instance_get_response(%{
+              "id" => "ocid1.instance..a",
+              "display-name" => "n",
+              "lifecycle-state" => "PROVISIONING",
+              "freeform-tags" => %{},
+              "time-created" => "2024-01-15T10:30:00.000Z"
+            })
+
+          command =~ "list-vnics" ->
+            vnic_list_response([])
+        end
+      end
+
+      assert {:ok, %Instance{public_ip: nil, private_ip: nil}} =
+               OciMachine.describe_instance("ocid1.instance..a", run_fn: run_fn)
+    end
+
+    test "fetch_tags/2 returns the instance's freeform-tags via describe_instance" do
+      run_fn = fn command, _cwd ->
+        cond do
+          command =~ "instance get" ->
+            instance_get_response(%{
+              "id" => "ocid1.instance..a",
+              "display-name" => "n",
+              "lifecycle-state" => "RUNNING",
+              "freeform-tags" => %{"K6Runner" => "true"},
+              "time-created" => "2024-01-15T10:30:00.000Z"
+            })
+
+          command =~ "list-vnics" ->
+            vnic_list_response([])
+        end
+      end
+
+      assert {:ok, %{"K6Runner" => "true"}} = OciMachine.fetch_tags("ocid1.instance..a", run_fn: run_fn)
+    end
+
+    test "instance_address/1 prefers ipv6, falls back to public_ip" do
+      assert {:ok, "2600:1f18::1"} =
+               OciMachine.instance_address(%Instance{ipv6: "2600:1f18::1", public_ip: "1.2.3.4"})
+
+      assert {:ok, "1.2.3.4"} = OciMachine.instance_address(%Instance{ipv6: nil, public_ip: "1.2.3.4"})
+    end
+
+    test "instance_address/1 errors when neither address is reachable" do
+      assert {:error, %ErrorMessage{code: :not_found}} =
+               OciMachine.instance_address(%Instance{id: "ocid1.instance..a", ipv6: nil, public_ip: nil})
+    end
+  end
+
+  describe "run_instance/2 — neutral spec to oci compute instance launch" do
+    defp neutral_spec do
+      %{
+        name: "K6-Runner-test-1",
+        instance_type: nil,
+        user_data: "#!/bin/bash\necho hi\n",
+        tags: [{:Name, "K6-Runner-test-1"}, {:Group, "My Backend"}, {:K6Runner, "true"}],
+        network: %{
+          key_name: "/tmp/key.pem",
+          subnet_id: nil,
+          security_group_id: nil,
+          ami_id: nil,
+          iam_instance_profile: nil
+        }
+      }
+    end
+
+    defp launch_response(instance_id) do
+      {:ok, Jason.encode!(%{"data" => %{"id" => instance_id, "lifecycle-state" => "PROVISIONING"}})}
+    end
+
+    defp launch_opts(extra \\ []) do
+      Keyword.merge(
+        [
+          oci_compartment_id: "ocid1.compartment..a",
+          oci_availability_domain: "abcd:AP-SEOUL-1-AD-1",
+          oci_subnet_id: "ocid1.subnet..a",
+          oci_base_image: "ocid1.image..a"
+        ],
+        extra
+      )
+    end
+
+    test "launches with compartment/AD/subnet/image from config, display-name and metadata.user_data from the spec" do
+      run_fn = capture_command(launch_response("ocid1.instance..new"))
+
+      assert {:ok, %Instance{id: "ocid1.instance..new"}} =
+               OciMachine.run_instance(neutral_spec(), Keyword.put(launch_opts(), :run_fn, run_fn))
+
+      assert_received {:oci_command, command}
+      assert command =~ "oci compute instance launch"
+      assert flag_value(command, "--compartment-id") === "ocid1.compartment..a"
+      assert flag_value(command, "--availability-domain") === "abcd:AP-SEOUL-1-AD-1"
+      assert flag_value(command, "--subnet-id") === "ocid1.subnet..a"
+      assert flag_value(command, "--image-id") === "ocid1.image..a"
+      assert flag_value(command, "--display-name") === "K6-Runner-test-1"
+      assert flag_value(command, "--assign-public-ip") === "true"
+
+      metadata = command |> flag_value("--metadata") |> Jason.decode!()
+      assert metadata === %{"user_data" => Base.encode64(neutral_spec().user_data)}
+
+      tags = command |> flag_value("--freeform-tags") |> Jason.decode!()
+      assert tags === %{"Name" => "K6-Runner-test-1", "Group" => "My Backend", "K6Runner" => "true"}
+    end
+
+    test "nil instance_type falls back to the configured shape, not a hardcoded AWS-shaped default" do
+      run_fn = capture_command(launch_response("ocid1.instance..new"))
+
+      OciMachine.run_instance(
+        neutral_spec(),
+        Keyword.merge(launch_opts(oci_shape: "VM.Standard.E5.Flex"), run_fn: run_fn)
+      )
+
+      assert_received {:oci_command, command}
+      assert flag_value(command, "--shape") === "VM.Standard.E5.Flex"
+    end
+
+    test "no configured shape falls back to a sane default, never AWS's t3.small" do
+      run_fn = capture_command(launch_response("ocid1.instance..new"))
+
+      OciMachine.run_instance(neutral_spec(), Keyword.put(launch_opts(), :run_fn, run_fn))
+
+      assert_received {:oci_command, command}
+      shape = flag_value(command, "--shape")
+      refute is_nil(shape)
+      refute shape === "t3.small"
+    end
+
+    test "an explicit spec instance_type overrides the configured shape" do
+      run_fn = capture_command(launch_response("ocid1.instance..new"))
+      spec = %{neutral_spec() | instance_type: "VM.Standard.E6.Flex"}
+
+      OciMachine.run_instance(spec, Keyword.merge(launch_opts(oci_shape: "VM.Standard.E5.Flex"), run_fn: run_fn))
+
+      assert_received {:oci_command, command}
+      assert flag_value(command, "--shape") === "VM.Standard.E6.Flex"
+    end
+
+    test "a Flex shape includes --shape-config with ocpus/memory; a fixed shape omits it" do
+      run_fn = capture_command(launch_response("ocid1.instance..new"))
+
+      OciMachine.run_instance(
+        neutral_spec(),
+        Keyword.merge(launch_opts(oci_shape: "VM.Standard.E5.Flex", oci_shape_ocpus: 2, oci_shape_memory_gbs: 16),
+          run_fn: run_fn
+        )
+      )
+
+      assert_received {:oci_command, flex_command}
+      shape_config = flex_command |> flag_value("--shape-config") |> Jason.decode!()
+      assert shape_config === %{"ocpus" => 2, "memoryInGBs" => 16}
+
+      run_fn2 = capture_command(launch_response("ocid1.instance..new2"))
+
+      OciMachine.run_instance(
+        neutral_spec(),
+        Keyword.merge(launch_opts(oci_shape: "VM.Standard2.1"), run_fn: run_fn2)
+      )
+
+      assert_received {:oci_command, fixed_command}
+      refute fixed_command =~ "--shape-config"
+    end
+
+    test "requires compartment_id and availability_domain instead of launching with nils" do
+      run_fn = capture_command(launch_response("unreachable"))
+
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} =
+               OciMachine.run_instance(neutral_spec(),
+                 oci_availability_domain: "abcd:AP-SEOUL-1-AD-1",
+                 oci_subnet_id: "s",
+                 oci_base_image: "i",
+                 run_fn: run_fn
+               )
+
+      assert message =~ "compartment_id"
+    end
+  end
+
+  describe "terminate_instance/2" do
+    test "terminates via oci compute instance terminate --force" do
+      run_fn = capture_command({:ok, ""})
+
+      assert :ok = OciMachine.terminate_instance("ocid1.instance..a", run_fn: run_fn)
+
+      assert_received {:oci_command, command}
+      assert command =~ "oci compute instance terminate"
+      assert flag_value(command, "--instance-id") === "ocid1.instance..a"
+      assert command =~ "--force"
+    end
+  end
+
+  describe "await_running/2" do
+    test "returns :ok once every instance reports RUNNING" do
+      run_fn = fn _command, _cwd ->
+        {:ok, Jason.encode!(%{"data" => %{"lifecycle-state" => "RUNNING"}})}
+      end
+
+      assert :ok = OciMachine.await_running(["ocid1.instance..a"], run_fn: run_fn)
+    end
+
+    test "polls until RUNNING, sleeping between attempts" do
+      queue_responses([
+        Jason.encode!(%{"data" => %{"lifecycle-state" => "PROVISIONING"}}),
+        Jason.encode!(%{"data" => %{"lifecycle-state" => "RUNNING"}})
+      ])
+
+      run_fn = fn _command, _cwd -> {:ok, next_response()} end
+      sleep_fn = fn _ms -> send(self(), :slept) end
+
+      assert :ok = OciMachine.await_running(["ocid1.instance..a"], run_fn: run_fn, sleep_fn: sleep_fn, retries: 3)
+      assert_received :slept
+    end
+
+    test "exhausts retries and returns a failed_dependency error rather than a false :ok" do
+      run_fn = fn _command, _cwd ->
+        {:ok, Jason.encode!(%{"data" => %{"lifecycle-state" => "PROVISIONING"}})}
+      end
+
+      sleep_fn = fn _ms -> :ok end
+
+      assert {:error, %ErrorMessage{code: :failed_dependency}} =
+               OciMachine.await_running(["ocid1.instance..a"], run_fn: run_fn, sleep_fn: sleep_fn, retries: 2)
+    end
+  end
+
+  describe "behaviour conformance — required callbacks not requested by the loadtest path" do
+    test "find_app_instances/3, start_instance/2, stop_instance/2 are honest not_implemented stubs" do
+      assert {:error, %ErrorMessage{code: :not_implemented}} =
+               OciMachine.find_app_instances("project", "app", [])
+
+      assert {:error, %ErrorMessage{code: :not_implemented}} = OciMachine.start_instance("i", [])
+      assert {:error, %ErrorMessage{code: :not_implemented}} = OciMachine.stop_instance("i", [])
+    end
+
+    test "exports every REQUIRED callback the Machine behaviour declares" do
+      Code.ensure_loaded!(OciMachine)
+
+      required =
+        DeployEx.Cloud.Machine.behaviour_info(:callbacks) --
+          DeployEx.Cloud.Machine.behaviour_info(:optional_callbacks)
+
+      missing = Enum.reject(required, fn {name, arity} -> function_exported?(OciMachine, name, arity) end)
+
+      assert missing === [], "OciMachine is missing required callbacks: #{inspect(missing)}"
+    end
+
+    test "also implements the optional callbacks the loadtest path needs" do
+      Code.ensure_loaded!(OciMachine)
+
+      for {name, arity} <- [run_instance: 2, terminate_instance: 2, await_running: 2] do
+        assert function_exported?(OciMachine, name, arity), "OciMachine is missing #{name}/#{arity}"
+      end
+    end
+  end
+end

--- a/test/deploy_ex/cloud/oci_machine_test.exs
+++ b/test/deploy_ex/cloud/oci_machine_test.exs
@@ -259,6 +259,19 @@ defmodule DeployEx.Cloud.OciMachineTest do
       assert metadata["user_data"] === Base.encode64("#!/bin/bash\necho hi\n")
     end
 
+    test "a :ssh_public_key that looks like a file PATH (not key contents) is a loud bad_request" do
+      opts =
+        launch_opts()
+        |> Keyword.put(:oci_ssh_public_key, "/home/me/.ssh/id_ed25519.pub")
+        |> Keyword.put(:run_fn, capture_command(launch_response("x")))
+
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} =
+               OciMachine.run_instance(neutral_spec(), opts)
+
+      assert message =~ "key contents"
+      refute_received {:oci_command, _}
+    end
+
     test "a missing :ssh_public_key config is a loud bad_request, not a keyless launch" do
       opts = launch_opts() |> Keyword.delete(:oci_ssh_public_key) |> Keyword.put(:run_fn, capture_command(launch_response("x")))
 

--- a/test/deploy_ex/cloud/oci_machine_test.exs
+++ b/test/deploy_ex/cloud/oci_machine_test.exs
@@ -153,7 +153,7 @@ defmodule DeployEx.Cloud.OciMachineTest do
               %Instance{
                 id: "ocid1.instance..a",
                 name: "K6-Runner-prod-1",
-                state: "RUNNING",
+                state: "running",
                 public_ip: "1.2.3.4",
                 private_ip: "10.0.0.5",
                 tags: %{"Name" => "K6-Runner-prod-1", "K6Runner" => "true"}
@@ -241,10 +241,32 @@ defmodule DeployEx.Cloud.OciMachineTest do
           oci_compartment_id: "ocid1.compartment..a",
           oci_availability_domain: "abcd:AP-SEOUL-1-AD-1",
           oci_subnet_id: "ocid1.subnet..a",
-          oci_base_image: "ocid1.image..a"
+          oci_base_image: "ocid1.image..a",
+          oci_ssh_public_key: "ssh-ed25519 AAAAtest key-comment"
         ],
         extra
       )
+    end
+
+    test "metadata carries ssh_authorized_keys from the :ssh_public_key config" do
+      run_fn = capture_command(launch_response("ocid1.instance..new"))
+
+      OciMachine.run_instance(neutral_spec(), Keyword.put(launch_opts(), :run_fn, run_fn))
+
+      assert_received {:oci_command, command}
+      metadata = command |> flag_value("--metadata") |> Jason.decode!()
+      assert metadata["ssh_authorized_keys"] === "ssh-ed25519 AAAAtest key-comment"
+      assert metadata["user_data"] === Base.encode64("#!/bin/bash\necho hi\n")
+    end
+
+    test "a missing :ssh_public_key config is a loud bad_request, not a keyless launch" do
+      opts = launch_opts() |> Keyword.delete(:oci_ssh_public_key) |> Keyword.put(:run_fn, capture_command(launch_response("x")))
+
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} =
+               OciMachine.run_instance(neutral_spec(), opts)
+
+      assert message =~ "ssh_public_key"
+      refute_received {:oci_command, _}
     end
 
     test "launches with compartment/AD/subnet/image from config, display-name and metadata.user_data from the spec" do
@@ -263,7 +285,10 @@ defmodule DeployEx.Cloud.OciMachineTest do
       assert flag_value(command, "--assign-public-ip") === "true"
 
       metadata = command |> flag_value("--metadata") |> Jason.decode!()
-      assert metadata === %{"user_data" => Base.encode64(neutral_spec().user_data)}
+      assert metadata === %{
+               "user_data" => Base.encode64(neutral_spec().user_data),
+               "ssh_authorized_keys" => "ssh-ed25519 AAAAtest key-comment"
+             }
 
       tags = command |> flag_value("--freeform-tags") |> Jason.decode!()
       assert tags === %{"Name" => "K6-Runner-test-1", "Group" => "My Backend", "K6Runner" => "true"}
@@ -356,6 +381,10 @@ defmodule DeployEx.Cloud.OciMachineTest do
   end
 
   describe "await_running/2" do
+    test "an empty instance-id list is an error, not a vacuous :ok" do
+      assert {:error, %ErrorMessage{code: :bad_request}} = OciMachine.await_running([], [])
+    end
+
     test "returns :ok once every instance reports RUNNING" do
       run_fn = fn _command, _cwd ->
         {:ok, Jason.encode!(%{"data" => %{"lifecycle-state" => "RUNNING"}})}

--- a/test/deploy_ex/cloud/oci_object_store_test.exs
+++ b/test/deploy_ex/cloud/oci_object_store_test.exs
@@ -115,13 +115,13 @@ defmodule DeployEx.Cloud.OciObjectStoreTest do
     test ":oci_region is the explicit override that does apply" do
       OciObjectStore.list_objects("bucket", stub(~s({"data": []})) ++ [oci_region: "ap-seoul-1"])
 
-      assert last_command() =~ "--region ap-seoul-1"
+      assert last_command() =~ "--region 'ap-seoul-1'"
     end
 
     test "instance_principal auth is selectable for on-instance use" do
       OciObjectStore.list_objects("bucket", stub(~s({"data": []})) ++ [oci_auth: "instance_principal"])
 
-      assert last_command() =~ "OCI_CLI_AUTH=instance_principal"
+      assert last_command() =~ "OCI_CLI_AUTH='instance_principal'"
     end
   end
 

--- a/test/deploy_ex/cloud/providers/oci_test.exs
+++ b/test/deploy_ex/cloud/providers/oci_test.exs
@@ -44,7 +44,9 @@ defmodule DeployEx.Cloud.Providers.OciTest do
         namespace: "mynamespace",
         shape: "VM.Standard.E5.Flex",
         shape_ocpus: 1,
-        shape_memory_gbs: 8
+        shape_memory_gbs: 8,
+        subnet_id: "ocid1.subnet.oc1..aaaa",
+        availability_domain: "abcd:AP-SEOUL-1-AD-1"
       ]
 
       assert {:ok, _} = NimbleOptions.validate(config, Oci.config_schema())

--- a/test/deploy_ex/cloud/providers/oci_test.exs
+++ b/test/deploy_ex/cloud/providers/oci_test.exs
@@ -48,7 +48,8 @@ defmodule DeployEx.Cloud.Providers.OciTest do
         shape_ocpus: 1,
         shape_memory_gbs: 8,
         subnet_id: "ocid1.subnet.oc1..aaaa",
-        availability_domain: "abcd:AP-SEOUL-1-AD-1"
+        availability_domain: "abcd:AP-SEOUL-1-AD-1",
+        ssh_public_key: "ssh-ed25519 AAAAtest key-comment"
       ]
 
       assert {:ok, _} = NimbleOptions.validate(config, Oci.config_schema())

--- a/test/deploy_ex/cloud/providers/oci_test.exs
+++ b/test/deploy_ex/cloud/providers/oci_test.exs
@@ -7,10 +7,12 @@ defmodule DeployEx.Cloud.Providers.OciTest do
     assert DeployEx.Cloud.Provider in (Oci.module_info(:attributes)[:behaviour] || [])
   end
 
-  test "capabilities/0 exposes the object store and security group and nothing else" do
+  test "capabilities/0 exposes object store, security, machine and infrastructure (LT-OCI S2)" do
     assert Oci.capabilities() === %{
              object_store: DeployEx.Cloud.OciObjectStore,
-             security: DeployEx.Cloud.OciSecurityGroup
+             security: DeployEx.Cloud.OciSecurityGroup,
+             machine: DeployEx.Cloud.OciMachine,
+             infrastructure: DeployEx.Cloud.OciInfrastructure
            }
   end
 

--- a/test/deploy_ex/cloud_test.exs
+++ b/test/deploy_ex/cloud_test.exs
@@ -172,6 +172,40 @@ defmodule DeployEx.CloudTest do
     end
   end
 
+  describe "ssh_user/1 — LT-OCI S1 accessor" do
+    test "resolves the AWS descriptor's admin user under the default provider" do
+      assert Cloud.ssh_user([]) === "admin"
+    end
+
+    test "resolves the OCI descriptor's ubuntu user under an explicit override" do
+      assert Cloud.ssh_user(provider: :oci) === "ubuntu"
+    end
+
+    test "falls back to admin for an unregistered provider instead of raising" do
+      assert Cloud.ssh_user(provider: :gcp) === "admin"
+    end
+  end
+
+  describe "resource_group/1 — LT-OCI S1 accessor" do
+    test "resolves through DeployEx.Config.aws_resource_group/0 under the default provider" do
+      assert Cloud.resource_group([]) === DeployEx.Config.aws_resource_group()
+    end
+
+    test "reads the :oci config namespace under an explicit override" do
+      assert Cloud.resource_group(provider: :oci) === DeployEx.Config.oci_setting(:resource_group)
+    end
+  end
+
+  describe "release_bucket/1 — LT-OCI S1 accessor" do
+    test "resolves through DeployEx.Config.aws_release_bucket/0 under the default provider" do
+      assert Cloud.release_bucket([]) === DeployEx.Config.aws_release_bucket()
+    end
+
+    test "reads the :oci config namespace under an explicit override" do
+      assert Cloud.release_bucket(provider: :oci) === DeployEx.Config.oci_setting(:release_bucket)
+    end
+  end
+
   describe "%Cloud.Instance{}" do
     test "has the exact provider-neutral field set" do
       keys =
@@ -204,6 +238,7 @@ defmodule DeployEx.CloudTest do
   describe "behaviours" do
     test "Machine declares its exact callback set" do
       assert callback_set(DeployEx.Cloud.Machine) === [
+               await_running: 2,
                delete_tags: 3,
                describe_instance: 2,
                fetch_tags: 2,
@@ -220,6 +255,7 @@ defmodule DeployEx.CloudTest do
 
     test "the Phase-5 callbacks are optional so AwsMachine conforms without them" do
       assert DeployEx.Cloud.Machine.behaviour_info(:optional_callbacks) |> Enum.sort() === [
+               await_running: 2,
                delete_tags: 3,
                put_tags: 3,
                run_instance: 2,

--- a/test/deploy_ex/cloud_test.exs
+++ b/test/deploy_ex/cloud_test.exs
@@ -20,9 +20,14 @@ defmodule DeployEx.CloudTest do
   end
 
   describe "capability/2 — explicit provider" do
-    test "an OCI capability is honestly not implemented" do
+    test "OCI now resolves machine/infrastructure too (LT-OCI S2)" do
+      assert Cloud.capability(:machine, provider: :oci) === {:ok, DeployEx.Cloud.OciMachine}
+      assert Cloud.capability(:infrastructure, provider: :oci) === {:ok, DeployEx.Cloud.OciInfrastructure}
+    end
+
+    test "a capability OCI does not implement is honestly not implemented" do
       assert {:error, %ErrorMessage{code: :not_implemented}} =
-               Cloud.capability(:machine, provider: :oci)
+               Cloud.capability(:autoscaling, provider: :oci)
     end
 
     test "an unknown provider errors instead of raising KeyError" do
@@ -35,11 +40,14 @@ defmodule DeployEx.CloudTest do
     test "accepts a descriptor MODULE and resolves through it" do
       assert Cloud.capability(:machine, provider: DeployEx.Cloud.Providers.Aws) ===
                {:ok, DeployEx.AwsMachine}
+
+      assert Cloud.capability(:machine, provider: DeployEx.Cloud.Providers.Oci) ===
+               {:ok, DeployEx.Cloud.OciMachine}
     end
 
     test "a module descriptor lacking the capability reports :not_implemented" do
       assert {:error, %ErrorMessage{code: :not_implemented}} =
-               Cloud.capability(:machine, provider: DeployEx.Cloud.Providers.Oci)
+               Cloud.capability(:autoscaling, provider: DeployEx.Cloud.Providers.Oci)
     end
 
     test "a module that is not a descriptor errors instead of raising" do

--- a/test/deploy_ex/cloud_test.exs
+++ b/test/deploy_ex/cloud_test.exs
@@ -257,6 +257,29 @@ defmodule DeployEx.CloudTest do
     end
   end
 
+  describe "aws?/1 — single shared answer for \"is this AWS\" (LT-OCI review-fix cycle 3, F1 recurrence)" do
+    test "true under the default provider" do
+      assert Cloud.aws?([]) === true
+    end
+
+    test "true for the atom override :aws" do
+      assert Cloud.aws?(provider: :aws) === true
+    end
+
+    test "true for the descriptor MODULE override — the exact case that recurred (F1)" do
+      assert Cloud.aws?(provider: DeployEx.Cloud.Providers.Aws) === true
+    end
+
+    test "false for a registered non-AWS provider" do
+      assert Cloud.aws?(provider: :oci) === false
+      assert Cloud.aws?(provider: DeployEx.Cloud.Providers.Oci) === false
+    end
+
+    test "false for an unregistered provider instead of raising" do
+      assert Cloud.aws?(provider: :gcp) === false
+    end
+  end
+
   describe "%Cloud.Instance{}" do
     test "has the exact provider-neutral field set" do
       keys =

--- a/test/deploy_ex/cloud_test.exs
+++ b/test/deploy_ex/cloud_test.exs
@@ -232,6 +232,31 @@ defmodule DeployEx.CloudTest do
     end
   end
 
+  describe "parse_provider/1 — safe CLI --provider flag parsing (LT-OCI review-fix)" do
+    test "parses a known provider string into its atom" do
+      assert Cloud.parse_provider("aws") === {:ok, :aws}
+      assert Cloud.parse_provider("oci") === {:ok, :oci}
+    end
+
+    test "nil (flag absent) resolves to nil, not an error" do
+      assert Cloud.parse_provider(nil) === {:ok, nil}
+    end
+
+    test "an unknown provider string errors instead of silently being swallowed" do
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} = Cloud.parse_provider("gcp")
+
+      assert message =~ "gcp"
+      assert message =~ "aws"
+      assert message =~ "oci"
+    end
+
+    test "a fresh, never-before-seen string still errors cleanly rather than raising" do
+      random = "totally-unrecognized-#{System.unique_integer([:positive])}"
+
+      assert {:error, %ErrorMessage{code: :bad_request}} = Cloud.parse_provider(random)
+    end
+  end
+
   describe "%Cloud.Instance{}" do
     test "has the exact provider-neutral field set" do
       keys =
@@ -309,8 +334,13 @@ defmodule DeployEx.CloudTest do
                find_instance_identity: 1,
                find_key_pair: 2,
                find_network: 1,
-               find_subnet: 1
+               find_subnet: 1,
+               gather_infrastructure: 1
              ]
+    end
+
+    test "gather_infrastructure/1 is optional so a provider conforms without it (LT-OCI review-fix)" do
+      assert DeployEx.Cloud.Infrastructure.behaviour_info(:optional_callbacks) === [gather_infrastructure: 1]
     end
 
     test "Security declares its exact callback set" do

--- a/test/deploy_ex/cloud_test.exs
+++ b/test/deploy_ex/cloud_test.exs
@@ -186,23 +186,49 @@ defmodule DeployEx.CloudTest do
     end
   end
 
-  describe "resource_group/1 — LT-OCI S1 accessor" do
+  describe "resource_group/1 — LT-OCI S1/review-fix accessor" do
     test "resolves through DeployEx.Config.aws_resource_group/0 under the default provider" do
-      assert Cloud.resource_group([]) === DeployEx.Config.aws_resource_group()
+      assert Cloud.resource_group([]) === {:ok, DeployEx.Config.aws_resource_group()}
     end
 
-    test "reads the :oci config namespace under an explicit override" do
-      assert Cloud.resource_group(provider: :oci) === DeployEx.Config.oci_setting(:resource_group)
+    test "resolves AWS's flat config when given the descriptor MODULE instead of the atom :aws" do
+      assert Cloud.resource_group(provider: DeployEx.Cloud.Providers.Aws) ===
+               {:ok, DeployEx.Config.aws_resource_group()}
+    end
+
+    test "reads the real, seeded :oci config namespace under an explicit atom override" do
+      assert Cloud.resource_group(provider: :oci) === {:ok, "OCI Test Backend"}
+    end
+
+    test "reads the :oci namespace when given the descriptor MODULE instead of the atom :oci" do
+      assert Cloud.resource_group(provider: DeployEx.Cloud.Providers.Oci) === {:ok, "OCI Test Backend"}
+    end
+
+    test "an unregistered provider errors instead of raising" do
+      assert {:error, %ErrorMessage{code: :not_implemented}} = Cloud.resource_group(provider: :gcp)
     end
   end
 
-  describe "release_bucket/1 — LT-OCI S1 accessor" do
+  describe "release_bucket/1 — LT-OCI S1/review-fix accessor" do
     test "resolves through DeployEx.Config.aws_release_bucket/0 under the default provider" do
-      assert Cloud.release_bucket([]) === DeployEx.Config.aws_release_bucket()
+      assert Cloud.release_bucket([]) === {:ok, DeployEx.Config.aws_release_bucket()}
     end
 
-    test "reads the :oci config namespace under an explicit override" do
-      assert Cloud.release_bucket(provider: :oci) === DeployEx.Config.oci_setting(:release_bucket)
+    test "resolves AWS's flat config when given the descriptor MODULE instead of the atom :aws" do
+      assert Cloud.release_bucket(provider: DeployEx.Cloud.Providers.Aws) ===
+               {:ok, DeployEx.Config.aws_release_bucket()}
+    end
+
+    test "a real, registered provider with the key genuinely unset errors loudly rather than nil" do
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} =
+               Cloud.release_bucket(provider: :oci)
+
+      assert message =~ "release_bucket"
+      assert message =~ "oci"
+    end
+
+    test "an unregistered provider errors instead of raising" do
+      assert {:error, %ErrorMessage{code: :not_implemented}} = Cloud.release_bucket(provider: :gcp)
     end
   end
 

--- a/test/deploy_ex/config_test.exs
+++ b/test/deploy_ex/config_test.exs
@@ -18,4 +18,25 @@ defmodule DeployEx.ConfigTest do
       assert Config.cloud_provider() === :aws
     end
   end
+
+  describe "provider_setting/2 — generic provider config namespace reader (LT-OCI review-fix)" do
+    test "reads a real, seeded key from the :oci namespace" do
+      assert Config.provider_setting(:oci, :resource_group) === "OCI Test Backend"
+    end
+
+    test "reads nil for an unset key in a real namespace" do
+      assert is_nil(Config.provider_setting(:oci, :vcn_cidr))
+    end
+
+    test "reads nil for a provider with no configured namespace at all" do
+      assert is_nil(Config.provider_setting(:gcp, :region))
+    end
+  end
+
+  describe "oci_setting/1 — delegates to provider_setting/2" do
+    test "reads the same value as provider_setting(:oci, key)" do
+      assert Config.oci_setting(:resource_group) === Config.provider_setting(:oci, :resource_group)
+      assert Config.oci_setting(:resource_group) === "OCI Test Backend"
+    end
+  end
 end

--- a/test/deploy_ex/k6_runner_test.exs
+++ b/test/deploy_ex/k6_runner_test.exs
@@ -525,6 +525,24 @@ defmodule DeployEx.K6RunnerTest do
         "</item></instancesSet></RunInstancesResponse>"
     end
 
+    test "no --instance-type override: the spec carries no default, AWS still ends up with t3.small (LT-OCI S2)" do
+      # instance_type defaults used to live in K6Runner (AWS-flavored "t3.small") and leaked
+      # into every provider's neutral spec. Moving the default into each provider's own
+      # run_instance/2 (AwsMachine falls back to "t3.small", OciMachine to its own shape
+      # default) means the spec itself carries nil when the caller gave no override, and each
+      # adapter picks its own honest default instead of inheriting AWS's.
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: run_instances_response("i-default-type")}}
+      end
+
+      assert {:ok, %K6Runner{instance_id: "i-default-type"}} =
+               K6Runner.create_instance(%{}, request_fn: request_fn)
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{params: ec2_params}}
+      assert ec2_params["InstanceType"] === "t3.small"
+    end
+
     test "creates the instance via the machine capability and returns a K6Runner" do
       request_fn = fn request, _config ->
         send(self(), {:ec2_request, request})

--- a/test/deploy_ex/k6_runner_test.exs
+++ b/test/deploy_ex/k6_runner_test.exs
@@ -447,6 +447,22 @@ defmodule DeployEx.K6RunnerTest do
         assert line =~ "DPkg::Lock::Timeout", "expected #{inspect(line)} to be lock-tolerant"
       end)
     end
+
+    test "branches on architecture (OCI Always-Free is arm64, k6 apt repo is amd64-only)", %{script: script} do
+      assert script =~ "dpkg --print-architecture"
+      assert script =~ ~S|= "arm64" ]; then|
+    end
+
+    test "arm64 installs the official k6 linux-arm64 binary, not apt", %{script: script} do
+      assert script =~ "k6-v2.2.0-linux-arm64.tar.gz"
+      assert script =~ "cp /tmp/k6-v2.2.0-linux-arm64/k6 /usr/local/bin/k6"
+      assert script =~ "chmod 0755 /usr/local/bin/k6"
+    end
+
+    test "amd64 keeps the apt install path (AWS invariance)", %{script: script} do
+      assert script =~ ~r/apt-get install.*\bk6\b/
+      assert script =~ "https://dl.k6.io/deb stable main"
+    end
   end
 
   describe "save_state/2 (routed through Cloud.capability(:object_store) — LT-OCI S1)" do

--- a/test/deploy_ex/k6_runner_test.exs
+++ b/test/deploy_ex/k6_runner_test.exs
@@ -217,7 +217,7 @@ defmodule DeployEx.K6RunnerTest do
 
       assert :ok = K6Runner.terminate_instance("i-contract-1", provider: :oci, run_fn: terminate_run_fn)
 
-      assert {:ok, %K6Runner{instance_id: "i-contract-1", state: "RUNNING"}} =
+      assert {:ok, %K6Runner{instance_id: "i-contract-1", state: "running"}} =
                K6Runner.verify_instance_exists(runner, provider: :oci, run_fn: describe_run_fn)
 
       # find_runners_from_ec2 is explicitly AWS-only regardless of S2 — this stays
@@ -275,7 +275,7 @@ defmodule DeployEx.K6RunnerTest do
 
       opts = [provider: :oci, bucket: "configured-bucket", run_fn: run_fn]
 
-      assert {:ok, %K6Runner{instance_id: "i-oci-stored", state: "RUNNING"}} =
+      assert {:ok, %K6Runner{instance_id: "i-oci-stored", state: "running"}} =
                K6Runner.resolve_runner(opts, K6Runner)
     end
   end

--- a/test/deploy_ex/k6_runner_test.exs
+++ b/test/deploy_ex/k6_runner_test.exs
@@ -245,6 +245,135 @@ defmodule DeployEx.K6RunnerTest do
     end
   end
 
+  describe "save_state/2 (routed through Cloud.capability(:object_store) — LT-OCI S1)" do
+    test "puts to the resolved release bucket at the state key" do
+      runner = %K6Runner{instance_id: "i-save-1"}
+
+      request_fn = fn request, _config ->
+        send(self(), {:s3_request, request})
+        {:ok, %{body: ""}}
+      end
+
+      assert {:ok, :saved} = K6Runner.save_state(runner, request_fn: request_fn)
+
+      assert_received {:s3_request, %ExAws.Operation.S3{bucket: bucket, path: path, http_method: :put}}
+      assert bucket === DeployEx.Config.aws_release_bucket()
+      assert path === "k6-runners/i-save-1.json"
+    end
+
+    test "an explicit :bucket opt overrides the resolved default" do
+      runner = %K6Runner{instance_id: "i-save-2"}
+
+      request_fn = fn request, _config ->
+        send(self(), {:s3_request, request})
+        {:ok, %{body: ""}}
+      end
+
+      K6Runner.save_state(runner, request_fn: request_fn, bucket: "custom-bucket")
+
+      assert_received {:s3_request, %ExAws.Operation.S3{bucket: "custom-bucket"}}
+    end
+  end
+
+  describe "fetch_state/2 (routed through Cloud.capability(:object_store) — LT-OCI S1)" do
+    test "decodes a found state object into a K6Runner struct" do
+      request_fn = fn _request, _config ->
+        {:ok, %{body: K6Runner.to_json(%K6Runner{instance_id: "i-fetch-1", state: "running"})}}
+      end
+
+      assert {:ok, %K6Runner{instance_id: "i-fetch-1", state: "running"}} =
+               K6Runner.fetch_state("i-fetch-1", request_fn: request_fn)
+    end
+
+    test "resolves a missing state object to {:ok, nil} rather than an error" do
+      request_fn = fn _request, _config ->
+        {:error, {:http_error, 404, %{body: ""}}}
+      end
+
+      assert {:ok, nil} = K6Runner.fetch_state("i-fetch-missing", request_fn: request_fn)
+    end
+  end
+
+  describe "delete_state/2 (routed through Cloud.capability(:object_store) — LT-OCI S1)" do
+    test "deletes the state object at the resolved bucket and key" do
+      request_fn = fn request, _config ->
+        send(self(), {:s3_request, request})
+        {:ok, %{body: ""}}
+      end
+
+      assert :ok = K6Runner.delete_state("i-delete-1", request_fn: request_fn)
+
+      assert_received {:s3_request, %ExAws.Operation.S3{path: "k6-runners/i-delete-1.json", http_method: :delete}}
+    end
+
+    test "treats a 404 from the object store as a successful idempotent delete (D-regression)" do
+      request_fn = fn _request, _config ->
+        {:error, {:http_error, 404, %{body: ""}}}
+      end
+
+      assert :ok = K6Runner.delete_state("i-already-gone", request_fn: request_fn)
+    end
+  end
+
+  describe "create_instance/2 (routed through Cloud.capability(:machine) — LT-OCI S1)" do
+    defp run_instances_response(instance_id) do
+      "<RunInstancesResponse><instancesSet><item>" <>
+        "<instanceId>#{instance_id}</instanceId>" <>
+        "</item></instancesSet></RunInstancesResponse>"
+    end
+
+    test "creates the instance via the machine capability and returns a K6Runner" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: run_instances_response("i-created-1")}}
+      end
+
+      params = %{
+        key_name: "my-key",
+        subnet_id: "subnet-123",
+        security_group_id: "sg-123",
+        ami_id: "ami-123",
+        iam_instance_profile: "profile-name",
+        instance_type: "t3.medium"
+      }
+
+      assert {:ok, %K6Runner{instance_id: "i-created-1", instance_name: instance_name}} =
+               K6Runner.create_instance(params, request_fn: request_fn)
+
+      refute is_nil(instance_name)
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{params: ec2_params}}
+      assert ec2_params["InstanceType"] === "t3.medium"
+      assert ec2_params["ImageId"] === "ami-123"
+      assert ec2_params["TagSpecification.1.Tag.1.Key"] === "Name"
+      assert ec2_params["TagSpecification.1.Tag.2.Key"] === "Group"
+      assert ec2_params["TagSpecification.1.Tag.2.Value"] === DeployEx.Cloud.resource_group([])
+    end
+  end
+
+  describe "terminate_instance/2 (routed through Cloud.capability(:machine) — LT-OCI S1)" do
+    test "terminates via the machine capability" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: "<TerminateInstancesResponse></TerminateInstancesResponse>"}}
+      end
+
+      assert :ok = K6Runner.terminate_instance("i-terminate-1", request_fn: request_fn)
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{action: :terminate_instances}}
+    end
+  end
+
+  describe "build_user_data/1 ssh user (LT-OCI S1)" do
+    test "defaults to admin under the AWS provider (unchanged AWS behavior)" do
+      assert K6Runner.build_user_data() =~ ~r/chown -R admin:admin \/srv\/k6/
+    end
+
+    test "resolves through Cloud.ssh_user/1 for an overridden provider" do
+      assert K6Runner.build_user_data(provider: :oci) =~ ~r/chown -R ubuntu:ubuntu \/srv\/k6/
+    end
+  end
+
   describe "resolve_runner/2 (shared runner resolution, extracted for LT-FIX-A)" do
     test "default path: returns a not_found error naming create_instance for a terminated-only runner" do
       assert {:error, %ErrorMessage{code: :not_found, message: message}} =

--- a/test/deploy_ex/k6_runner_test.exs
+++ b/test/deploy_ex/k6_runner_test.exs
@@ -277,6 +277,25 @@ defmodule DeployEx.K6RunnerTest do
                K6Runner.verify_instance_exists(runner, request_fn: request_fn)
     end
 
+    test "does NOT leak the caller's opts (e.g. a --pem path) into the downstream EC2 request params (G1 leak class, end-to-end)" do
+      request_fn = fn request, _config ->
+        send(self(), {:ec2_request, request})
+        {:ok, %{body: describe_instance_response("i-found-2", "running", "10.0.0.6")}}
+      end
+
+      runner = %K6Runner{instance_id: "i-found-2"}
+
+      K6Runner.verify_instance_exists(runner,
+        request_fn: request_fn,
+        pem: "/secret/path/key.pem",
+        quiet: true
+      )
+
+      assert_received {:ec2_request, %ExAws.Operation.Query{params: params}}
+      refute Map.has_key?(params, "Pem")
+      refute Map.has_key?(params, "Quiet")
+    end
+
     test "not found: deletes the stale state and returns {:ok, nil}" do
       request_fn = fn
         %ExAws.Operation.Query{}, _config ->
@@ -637,6 +656,15 @@ defmodule DeployEx.K6RunnerTest do
       end
 
       K6Runner.find_runners_from_ec2(provider: :oci, request_fn: request_fn)
+    end
+
+    test "the descriptor MODULE override for AWS still paginates (F1 recurrence guard, review-fix cycle 3)" do
+      request_fn = fn _request, _config ->
+        {:ok, %{body: "<DescribeInstancesResponse><reservationSet/></DescribeInstancesResponse>"}}
+      end
+
+      assert {:ok, []} =
+               K6Runner.find_runners_from_ec2(provider: DeployEx.Cloud.Providers.Aws, request_fn: request_fn)
     end
   end
 

--- a/test/deploy_ex/k6_runner_test.exs
+++ b/test/deploy_ex/k6_runner_test.exs
@@ -175,6 +175,104 @@ defmodule DeployEx.K6RunnerTest do
     end
   end
 
+  describe "K6Runner :oci contract — not_implemented vs OCI-routed (LT-OCI review-fix)" do
+    test "machine ops are not_implemented under :oci — the Machine capability is not wired yet" do
+      runner = %K6Runner{instance_id: "i-contract-1"}
+
+      assert {:error, %ErrorMessage{code: :not_implemented}} =
+               K6Runner.create_instance(%{}, provider: :oci)
+
+      assert {:error, %ErrorMessage{code: :not_implemented}} =
+               K6Runner.terminate_instance("i-contract-1", provider: :oci)
+
+      assert {:error, %ErrorMessage{code: :not_implemented}} =
+               K6Runner.verify_instance_exists(runner, provider: :oci)
+
+      assert {:error, %ErrorMessage{code: :not_implemented}} =
+               K6Runner.find_runners_from_ec2(provider: :oci)
+    end
+
+    test "state ops route to OciObjectStore — blocked only by unset release_bucket, never :not_implemented" do
+      results = [
+        save_state: K6Runner.save_state(%K6Runner{instance_id: "i-contract-2"}, provider: :oci),
+        fetch_state: K6Runner.fetch_state("i-contract-2", provider: :oci),
+        fetch_all_runners: K6Runner.fetch_all_runners(provider: :oci),
+        delete_state: K6Runner.delete_state("i-contract-2", provider: :oci)
+      ]
+
+      Enum.each(results, fn {label, result} ->
+        assert {:error, %ErrorMessage{code: :bad_request}} = result,
+               "#{label} under :oci expected :bad_request (unset release_bucket), got #{inspect(result)}"
+      end)
+    end
+  end
+
+  describe "verify_instance_exists/2 (routed through Cloud.capability(:machine) — LT-OCI review-fix)" do
+    defp describe_instance_response(instance_id, state, private_ip) do
+      "<DescribeInstancesResponse><reservationSet><item><instancesSet><item>" <>
+        "<instanceId>#{instance_id}</instanceId>" <>
+        "<instanceState><name>#{state}</name></instanceState>" <>
+        "<privateIpAddress>#{private_ip}</privateIpAddress>" <>
+        "</item></instancesSet></item></reservationSet></DescribeInstancesResponse>"
+    end
+
+    defp describe_instance_not_found_response do
+      "<DescribeInstancesResponse><reservationSet/></DescribeInstancesResponse>"
+    end
+
+    test "returns {:ok, nil} for nil input, opts ignored" do
+      assert K6Runner.verify_instance_exists(nil, provider: :oci) === {:ok, nil}
+    end
+
+    test "found instance: maps the normalized Instance struct fields onto the runner" do
+      request_fn = fn _request, _config ->
+        {:ok, %{body: describe_instance_response("i-found-1", "running", "10.0.0.5")}}
+      end
+
+      runner = %K6Runner{instance_id: "i-found-1"}
+
+      assert {:ok, %K6Runner{instance_id: "i-found-1", state: "running", private_ip: "10.0.0.5"}} =
+               K6Runner.verify_instance_exists(runner, request_fn: request_fn)
+    end
+
+    test "not found: deletes the stale state and returns {:ok, nil}" do
+      request_fn = fn
+        %ExAws.Operation.Query{}, _config ->
+          {:ok, %{body: describe_instance_not_found_response()}}
+
+        %ExAws.Operation.S3{} = request, _config ->
+          send(self(), {:s3_delete_request, request})
+          {:ok, %{body: ""}}
+      end
+
+      runner = %K6Runner{instance_id: "i-stale-1"}
+
+      assert {:ok, nil} = K6Runner.verify_instance_exists(runner, request_fn: request_fn)
+      assert_received {:s3_delete_request, %ExAws.Operation.S3{http_method: :delete}}
+    end
+
+    test "not found, but the state delete itself fails: propagates the error rather than crashing" do
+      request_fn = fn
+        %ExAws.Operation.Query{}, _config ->
+          {:ok, %{body: describe_instance_not_found_response()}}
+
+        %ExAws.Operation.S3{}, _config ->
+          {:error, {:http_error, 500, %{body: "boom"}}}
+      end
+
+      runner = %K6Runner{instance_id: "i-stale-delete-fails"}
+
+      assert {:error, %ErrorMessage{}} = K6Runner.verify_instance_exists(runner, request_fn: request_fn)
+    end
+
+    test "capability not implemented (e.g. under :oci): propagates the error WITHOUT deleting state (cross-provider leak guard)" do
+      runner = %K6Runner{instance_id: "i-oci-1"}
+
+      assert {:error, %ErrorMessage{code: :not_implemented}} =
+               K6Runner.verify_instance_exists(runner, provider: :oci)
+    end
+  end
+
   describe "build_user_data/0 (D1: debian-13 compatibility)" do
     setup do
       %{script: K6Runner.build_user_data()}
@@ -469,6 +567,21 @@ defmodule DeployEx.K6RunnerTest do
   # Behavioural pagination tests. Responses are queued in the process dictionary — per-PID
   # isolated, no setup/teardown. Mirrors test/deploy_ex/cloud/pagination_test.exs: replacing the
   # recursion with a single request makes these red.
+  describe "find_runners_from_ec2/1 provider guard (LT-OCI review-fix)" do
+    test "errors instead of paginating EC2 under a non-AWS provider (must not print AWS runners as OCI)" do
+      assert {:error, %ErrorMessage{code: :not_implemented}} =
+               K6Runner.find_runners_from_ec2(provider: :oci)
+    end
+
+    test "does not touch ExAws at all under a non-AWS provider" do
+      request_fn = fn _request, _config ->
+        flunk("find_runners_from_ec2 must not call ExAws under a non-AWS provider")
+      end
+
+      K6Runner.find_runners_from_ec2(provider: :oci, request_fn: request_fn)
+    end
+  end
+
   describe "find_runners_from_ec2/1 pagination" do
     defp queue_responses(responses), do: Process.put(:responses, responses)
 

--- a/test/deploy_ex/k6_runner_test.exs
+++ b/test/deploy_ex/k6_runner_test.exs
@@ -315,6 +315,50 @@ defmodule DeployEx.K6RunnerTest do
     end
   end
 
+  describe "bucket resolution errors loudly instead of proceeding with nil (LT-OCI review-fix)" do
+    test "save_state propagates a bad_request instead of writing to an empty container name" do
+      runner = %K6Runner{instance_id: "i-unset-bucket"}
+
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} =
+               K6Runner.save_state(runner, provider: :oci)
+
+      assert message =~ "release_bucket"
+    end
+
+    test "an explicit :bucket opt still bypasses the Cloud lookup entirely, even under a provider with no configured bucket" do
+      runner = %K6Runner{instance_id: "i-explicit-bucket"}
+
+      # provider: :oci routes save_state through OciObjectStore (its DI seam is :run_fn, not
+      # ExAws's :request_fn) — :oci has no configured release_bucket in test config at all, so
+      # a successful save here can only mean the explicit :bucket opt was used directly, never
+      # routed through Cloud.release_bucket(provider: :oci) (which errors for this exact config).
+      run_fn = fn command, _cwd ->
+        send(self(), {:oci_command, command})
+        {:ok, ""}
+      end
+
+      assert {:ok, :saved} =
+               K6Runner.save_state(runner, provider: :oci, bucket: "explicit-bucket", run_fn: run_fn)
+
+      assert_received {:oci_command, command}
+      assert command =~ "--bucket-name 'explicit-bucket'"
+    end
+
+    test "fetch_state propagates a bad_request instead of reading from an empty container name" do
+      assert {:error, %ErrorMessage{code: :bad_request}} =
+               K6Runner.fetch_state("i-unset-bucket", provider: :oci)
+    end
+
+    test "fetch_all_runners propagates a bad_request instead of listing an empty container name" do
+      assert {:error, %ErrorMessage{code: :bad_request}} = K6Runner.fetch_all_runners(provider: :oci)
+    end
+
+    test "delete_state propagates a bad_request instead of deleting from an empty container name" do
+      assert {:error, %ErrorMessage{code: :bad_request}} =
+               K6Runner.delete_state("i-unset-bucket", provider: :oci)
+    end
+  end
+
   describe "create_instance/2 (routed through Cloud.capability(:machine) — LT-OCI S1)" do
     defp run_instances_response(instance_id) do
       "<RunInstancesResponse><instancesSet><item>" <>
@@ -347,7 +391,8 @@ defmodule DeployEx.K6RunnerTest do
       assert ec2_params["ImageId"] === "ami-123"
       assert ec2_params["TagSpecification.1.Tag.1.Key"] === "Name"
       assert ec2_params["TagSpecification.1.Tag.2.Key"] === "Group"
-      assert ec2_params["TagSpecification.1.Tag.2.Value"] === DeployEx.Cloud.resource_group([])
+      assert {:ok, expected_resource_group} = DeployEx.Cloud.resource_group([])
+      assert ec2_params["TagSpecification.1.Tag.2.Value"] === expected_resource_group
     end
   end
 

--- a/test/deploy_ex/k6_runner_test.exs
+++ b/test/deploy_ex/k6_runner_test.exs
@@ -6,25 +6,41 @@ defmodule DeployEx.K6RunnerTest do
   defmodule ResolveFakeTerminated do
     def fetch_all_runners(_opts), do: {:ok, [%K6Runner{instance_id: "i-dead"}]}
     def fetch_state(_instance_id, _opts), do: {:ok, %K6Runner{instance_id: "i-dead"}}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
   end
 
   defmodule ResolveFakeAbsent do
     def fetch_all_runners(_opts), do: {:ok, []}
     def fetch_state(_instance_id, _opts), do: {:ok, nil}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
   end
 
   defmodule ResolveFakeFetchYieldsNil do
     def fetch_all_runners(_opts), do: {:ok, nil}
     def fetch_state(_instance_id, _opts), do: {:ok, nil}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
   end
 
   defmodule ResolveFakeActive do
     def fetch_all_runners(_opts), do: {:ok, [%K6Runner{instance_id: "i-live"}]}
     def fetch_state(_instance_id, _opts), do: {:ok, %K6Runner{instance_id: "i-live"}}
-    def verify_instance_exists(runner), do: {:ok, %{runner | state: "running"}}
+    def verify_instance_exists(runner, _opts \\ []), do: {:ok, %{runner | state: "running"}}
+  end
+
+  defmodule ResolveOptsCapture do
+    @moduledoc """
+    Captures the opts resolve_runner/2 passes into verify_instance_exists — closes the class
+    of bug where a dropped-opts call site can't be caught by a contract test that passes
+    `provider: :oci` directly to verify_instance_exists itself (LT-OCI review-fix cycle 2).
+    """
+
+    def fetch_all_runners(_opts), do: {:ok, [%K6Runner{instance_id: "i-opts-capture"}]}
+    def fetch_state(_instance_id, _opts), do: {:ok, %K6Runner{instance_id: "i-opts-capture"}}
+
+    def verify_instance_exists(runner, opts) do
+      send(self(), {:verify_instance_exists_called, runner, opts})
+      {:ok, %{runner | state: "running"}}
+    end
   end
 
   defp line_index(script, regex) do
@@ -204,6 +220,32 @@ defmodule DeployEx.K6RunnerTest do
         assert {:error, %ErrorMessage{code: :bad_request}} = result,
                "#{label} under :oci expected :bad_request (unset release_bucket), got #{inspect(result)}"
       end)
+    end
+
+    test "with a CONFIGURED oci bucket and a real stored runner, resolve_runner reaches :not_implemented cleanly — never AWS (review cycle 2 item 3)" do
+      # Simulates the exact reviewer-measured scenario: bucket configured (via the explicit
+      # :bucket opt, bypassing the unset-namespace error) and a runner actually on disk, proving
+      # resolution stops at the not-yet-wired machine capability instead of silently falling
+      # through to AwsMachine/EC2 and, on a miss there, deleting the real OCI state object.
+      stored_runner = %K6Runner{instance_id: "i-oci-stored", state: "running"}
+
+      run_fn = fn command, _cwd ->
+        cond do
+          command =~ "os object list" ->
+            {:ok, Jason.encode!(%{"data" => [%{"name" => "k6-runners/i-oci-stored.json"}]})}
+
+          command =~ "os object get" ->
+            [_match, path] = Regex.run(~r/--file '([^']+)'/, command)
+            File.write!(path, K6Runner.to_json(stored_runner))
+            {:ok, ""}
+
+          true ->
+            flunk("unexpected oci command: #{command}")
+        end
+      end
+
+      assert {:error, %ErrorMessage{code: :not_implemented}} =
+               K6Runner.resolve_runner([provider: :oci, bucket: "configured-bucket", run_fn: run_fn], K6Runner)
     end
   end
 
@@ -561,6 +603,22 @@ defmodule DeployEx.K6RunnerTest do
     test "--instance-id path: returns the verified runner for a live instance id" do
       assert {:ok, %K6Runner{instance_id: "i-live", state: "running"}} =
                K6Runner.resolve_runner([instance_id: "i-live"], ResolveFakeActive)
+    end
+  end
+
+  describe "resolve_runner/2 threads opts into verify_instance_exists (LT-OCI review-fix cycle 2)" do
+    test "default path: a :provider override reaches verify_instance_exists, not just fetch_all_runners" do
+      K6Runner.resolve_runner([provider: :oci], ResolveOptsCapture)
+
+      assert_received {:verify_instance_exists_called, _runner, opts}
+      assert opts[:provider] === :oci
+    end
+
+    test "--instance-id path: a :provider override reaches verify_instance_exists, not just fetch_state" do
+      K6Runner.resolve_runner([provider: :oci, instance_id: "i-opts-capture"], ResolveOptsCapture)
+
+      assert_received {:verify_instance_exists_called, _runner, opts}
+      assert opts[:provider] === :oci
     end
   end
 

--- a/test/deploy_ex/k6_runner_test.exs
+++ b/test/deploy_ex/k6_runner_test.exs
@@ -191,19 +191,37 @@ defmodule DeployEx.K6RunnerTest do
     end
   end
 
-  describe "K6Runner :oci contract — not_implemented vs OCI-routed (LT-OCI review-fix)" do
-    test "machine ops are not_implemented under :oci — the Machine capability is not wired yet" do
+  describe "K6Runner :oci contract — not_implemented vs OCI-routed (LT-OCI S2 update)" do
+    test "machine ops now route to OciMachine (LT-OCI S2) — no longer not_implemented" do
       runner = %K6Runner{instance_id: "i-contract-1"}
+      terminate_run_fn = fn _command, _cwd -> {:ok, ""} end
 
-      assert {:error, %ErrorMessage{code: :not_implemented}} =
+      describe_run_fn = fn command, _cwd ->
+        cond do
+          command =~ "instance get" ->
+            {:ok, Jason.encode!(%{"data" => %{"id" => "i-contract-1", "lifecycle-state" => "RUNNING", "freeform-tags" => %{}}})}
+
+          command =~ "list-vnics" ->
+            {:ok, Jason.encode!(%{"data" => []})}
+        end
+      end
+
+      # create_instance still needs subnet_id/base_image/availability_domain even when a
+      # run_fn is given — those are checked before the CLI is ever called (no run_fn needed
+      # to exercise this specific error), proving the request reached OciMachine, not a
+      # not_implemented short-circuit at the capability lookup.
+      assert {:error, %ErrorMessage{code: :bad_request, message: create_message}} =
                K6Runner.create_instance(%{}, provider: :oci)
 
-      assert {:error, %ErrorMessage{code: :not_implemented}} =
-               K6Runner.terminate_instance("i-contract-1", provider: :oci)
+      assert create_message =~ "compartment_id"
 
-      assert {:error, %ErrorMessage{code: :not_implemented}} =
-               K6Runner.verify_instance_exists(runner, provider: :oci)
+      assert :ok = K6Runner.terminate_instance("i-contract-1", provider: :oci, run_fn: terminate_run_fn)
 
+      assert {:ok, %K6Runner{instance_id: "i-contract-1", state: "RUNNING"}} =
+               K6Runner.verify_instance_exists(runner, provider: :oci, run_fn: describe_run_fn)
+
+      # find_runners_from_ec2 is explicitly AWS-only regardless of S2 — this stays
+      # not_implemented forever, it is not part of the machine-capability wiring.
       assert {:error, %ErrorMessage{code: :not_implemented}} =
                K6Runner.find_runners_from_ec2(provider: :oci)
     end
@@ -222,11 +240,13 @@ defmodule DeployEx.K6RunnerTest do
       end)
     end
 
-    test "with a CONFIGURED oci bucket and a real stored runner, resolve_runner reaches :not_implemented cleanly — never AWS (review cycle 2 item 3)" do
+    test "with oci bucket + machine config + a stored runner, resolve_runner verifies via OciMachine, never AWS" do
       # Simulates the exact reviewer-measured scenario: bucket configured (via the explicit
-      # :bucket opt, bypassing the unset-namespace error) and a runner actually on disk, proving
-      # resolution stops at the not-yet-wired machine capability instead of silently falling
-      # through to AwsMachine/EC2 and, on a miss there, deleting the real OCI state object.
+      # :bucket opt, bypassing the unset-namespace error) and a runner actually on disk. As of
+      # S2, OciMachine is wired, so resolution now goes all the way through to a verified
+      # runner via OCI's own CLI calls — the point being it is OciMachine doing the verifying,
+      # never AwsMachine/EC2, so a miss there would delete the real OCI state object correctly
+      # scoped to OCI, not based on an AWS lookup against the wrong provider's instances.
       stored_runner = %K6Runner{instance_id: "i-oci-stored", state: "running"}
 
       run_fn = fn command, _cwd ->
@@ -239,13 +259,24 @@ defmodule DeployEx.K6RunnerTest do
             File.write!(path, K6Runner.to_json(stored_runner))
             {:ok, ""}
 
+          command =~ "instance get" ->
+            {:ok,
+             Jason.encode!(%{
+               "data" => %{"id" => "i-oci-stored", "lifecycle-state" => "RUNNING", "freeform-tags" => %{}}
+             })}
+
+          command =~ "list-vnics" ->
+            {:ok, Jason.encode!(%{"data" => []})}
+
           true ->
             flunk("unexpected oci command: #{command}")
         end
       end
 
-      assert {:error, %ErrorMessage{code: :not_implemented}} =
-               K6Runner.resolve_runner([provider: :oci, bucket: "configured-bucket", run_fn: run_fn], K6Runner)
+      opts = [provider: :oci, bucket: "configured-bucket", run_fn: run_fn]
+
+      assert {:ok, %K6Runner{instance_id: "i-oci-stored", state: "RUNNING"}} =
+               K6Runner.resolve_runner(opts, K6Runner)
     end
   end
 
@@ -326,11 +357,25 @@ defmodule DeployEx.K6RunnerTest do
       assert {:error, %ErrorMessage{}} = K6Runner.verify_instance_exists(runner, request_fn: request_fn)
     end
 
-    test "capability not implemented (e.g. under :oci): propagates the error WITHOUT deleting state (cross-provider leak guard)" do
-      runner = %K6Runner{instance_id: "i-oci-1"}
+    test "capability not implemented (e.g. an unregistered provider): propagates the error WITHOUT deleting state (cross-provider leak guard)" do
+      # :oci's machine capability is wired as of LT-OCI S2, so this now needs a provider that
+      # is genuinely never implemented to exercise the capability-lookup-failure branch of
+      # verify_instance_exists/2 (as opposed to :oci's own describe_instance failure modes,
+      # covered separately below).
+      runner = %K6Runner{instance_id: "i-gcp-1"}
 
       assert {:error, %ErrorMessage{code: :not_implemented}} =
-               K6Runner.verify_instance_exists(runner, provider: :oci)
+               K6Runner.verify_instance_exists(runner, provider: :gcp)
+    end
+
+    test "a real OCI describe_instance failure (e.g. under :oci) also propagates WITHOUT deleting state" do
+      runner = %K6Runner{instance_id: "i-oci-1"}
+
+      run_fn = fn command, _cwd ->
+        {:error, ErrorMessage.internal_server_error("#{command} exited 1: boom", %{output: "boom", code: 1, command: command})}
+      end
+
+      assert {:error, %ErrorMessage{}} = K6Runner.verify_instance_exists(runner, provider: :oci, run_fn: run_fn)
     end
   end
 

--- a/test/deploy_ex/ssh_test.exs
+++ b/test/deploy_ex/ssh_test.exs
@@ -15,6 +15,26 @@ defmodule DeployEx.SSHTest do
   -----END OPENSSH PRIVATE KEY-----
   """
 
+  describe "connect_options/2 — pure :ssh.connect options builder (LT-OCI review-fix)" do
+    test "carries the given user as a charlist under :user" do
+      opts = SSH.connect_options("1.2.3.4", "admin", "/tmp/key_dir")
+
+      assert opts[:user] === ~c"admin"
+    end
+
+    test "resolves a non-default ssh user (e.g. OCI's ubuntu)" do
+      opts = SSH.connect_options("1.2.3.4", "ubuntu", "/tmp/key_dir")
+
+      assert opts[:user] === ~c"ubuntu"
+    end
+
+    test "carries the given key dir as a charlist under :user_dir" do
+      opts = SSH.connect_options("1.2.3.4", "admin", "/tmp/some_key_dir")
+
+      assert opts[:user_dir] === ~c"/tmp/some_key_dir"
+    end
+  end
+
   describe "identity_filename/1 (LT-D12: pem loading for arbitrary filenames)" do
     test "classifies a traditional RSA PEM as id_rsa" do
       assert SSH.identity_filename(@rsa_pem) === "id_rsa"

--- a/test/mix/deploy_ex_helpers_test.exs
+++ b/test/mix/deploy_ex_helpers_test.exs
@@ -1,0 +1,26 @@
+defmodule DeployExHelpersTest do
+  @moduledoc """
+  Focused test for `DeployExHelpers.parse_provider_opt!/1` — the shared `--provider` CLI flag
+  validator the load_test mix tasks route through (LT-OCI review-fix item 7: OptionParser was
+  silently swallowing an unrecognized `--provider` value, so `--provider oci` ran against AWS).
+  """
+
+  use ExUnit.Case, async: true
+
+  describe "parse_provider_opt!/1" do
+    test "leaves opts unchanged when :provider is absent" do
+      assert DeployExHelpers.parse_provider_opt!(quiet: true) === [quiet: true]
+    end
+
+    test "replaces a valid provider string with its atom" do
+      assert DeployExHelpers.parse_provider_opt!(provider: "oci", quiet: true) ===
+               [provider: :oci, quiet: true]
+    end
+
+    test "raises Mix.Error naming the bad value for an unrecognized provider string" do
+      assert_raise Mix.Error, ~r/gcp/, fn ->
+        DeployExHelpers.parse_provider_opt!(provider: "gcp")
+      end
+    end
+  end
+end

--- a/test/mix/tasks/deploy_ex_load_test_create_instance_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_create_instance_test.exs
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstanceTest do
 
   defmodule FakeK6RunnerOrphaned do
     def fetch_state(_instance_id, _opts), do: {:ok, %K6Runner{instance_id: "i-orphan"}}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
 
     def save_state(runner, _opts) do
       send(self(), {:save_state_called, runner.instance_id})
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstanceTest do
 
   defmodule FakeK6RunnerHealthy do
     def fetch_state(_instance_id, _opts), do: {:ok, %K6Runner{instance_id: "i-healthy"}}
-    def verify_instance_exists(runner), do: {:ok, %{runner | state: "running"}}
+    def verify_instance_exists(runner, _opts \\ []), do: {:ok, %{runner | state: "running"}}
     def save_state(_runner, _opts), do: {:ok, :saved}
   end
 

--- a/test/mix/tasks/deploy_ex_load_test_create_instance_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_create_instance_test.exs
@@ -20,6 +20,26 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstanceTest do
     def save_state(_runner, _opts), do: {:ok, :saved}
   end
 
+  describe "parse_args/1 — --provider CLI flag (LT-OCI review-fix item 7)" do
+    test "a valid --provider flag is converted to an atom in the returned opts" do
+      {opts, _extra_args} = CreateInstance.parse_args(["--provider", "oci"])
+
+      assert opts[:provider] === :oci
+    end
+
+    test "no --provider flag leaves :provider absent (defaults resolve through Cloud.active_provider/1 later)" do
+      {opts, _extra_args} = CreateInstance.parse_args(["--instance-type", "t3.medium"])
+
+      refute Keyword.has_key?(opts, :provider)
+    end
+
+    test "an unrecognized --provider value raises Mix.Error instead of silently running against AWS" do
+      assert_raise Mix.Error, ~r/gcp/, fn ->
+        CreateInstance.parse_args(["--provider", "gcp"])
+      end
+    end
+  end
+
   describe "terminate_all_runners/3 (D5: --force = replace)" do
     test "terminates every runner it is given" do
       runners = [

--- a/test/mix/tasks/deploy_ex_load_test_create_instance_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_create_instance_test.exs
@@ -40,6 +40,21 @@ defmodule Mix.Tasks.DeployEx.LoadTest.CreateInstanceTest do
     end
   end
 
+  describe "gather_infrastructure/1 — routes through Cloud.capability(:infrastructure), keeps :run_fn/:pem (LT-OCI S2)" do
+    test "under :oci, a run_fn/oci config override reaches OciInfrastructure end-to-end" do
+      opts = [
+        provider: :oci,
+        oci_subnet_id: "ocid1.subnet..a",
+        oci_base_image: "ocid1.image..a",
+        pem: "/tmp/explicit-key.pem",
+        quiet: true
+      ]
+
+      assert {:ok, %{subnet_id: "ocid1.subnet..a", image_id: "ocid1.image..a", key_name: "/tmp/explicit-key.pem"}} =
+               CreateInstance.gather_infrastructure(opts)
+    end
+  end
+
   describe "terminate_all_runners/3 (D5: --force = replace)" do
     test "terminates every runner it is given" do
       runners = [

--- a/test/mix/tasks/deploy_ex_load_test_exec_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_exec_test.exs
@@ -6,19 +6,19 @@ defmodule Mix.Tasks.DeployEx.LoadTest.ExecTest do
   defmodule FakeK6RunnerTerminated do
     def fetch_all_runners(_opts), do: {:ok, [%DeployEx.K6Runner{instance_id: "i-dead"}]}
     def fetch_state(_instance_id, _opts), do: {:ok, %DeployEx.K6Runner{instance_id: "i-dead"}}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
   end
 
   defmodule FakeK6RunnerAbsent do
     def fetch_all_runners(_opts), do: {:ok, []}
     def fetch_state(_instance_id, _opts), do: {:ok, nil}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
   end
 
   defmodule FakeK6RunnerFetchYieldsNil do
     def fetch_all_runners(_opts), do: {:ok, nil}
     def fetch_state(_instance_id, _opts), do: {:ok, nil}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
   end
 
   defmodule FakeK6RunnerActive do
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.ExecTest do
       {:ok, %DeployEx.K6Runner{instance_id: "i-live", public_ip: "1.2.3.4"}}
     end
 
-    def verify_instance_exists(runner), do: {:ok, %{runner | state: "running"}}
+    def verify_instance_exists(runner, _opts \\ []), do: {:ok, %{runner | state: "running"}}
   end
 
   describe "resolve_runner/2 default path (no --instance-id)" do

--- a/test/mix/tasks/deploy_ex_load_test_exec_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_exec_test.exs
@@ -113,6 +113,33 @@ defmodule Mix.Tasks.DeployEx.LoadTest.ExecTest do
     end
   end
 
+  describe "ssh_args/4 — pure ssh argv builder, pins the actual transport call sites (LT-OCI review-fix)" do
+    test "builds the exact ssh argv under the default AWS provider" do
+      assert Exec.ssh_args("1.2.3.4", "/tmp/key.pem", "k6 version", []) === [
+               "-i",
+               "/tmp/key.pem",
+               "-o",
+               "StrictHostKeyChecking=no",
+               "-o",
+               "UserKnownHostsFile=/dev/null",
+               "admin@1.2.3.4",
+               "k6 version"
+             ]
+    end
+
+    test "resolves the ssh user through Cloud.ssh_user/1 for an overridden provider" do
+      argv = Exec.ssh_args("1.2.3.4", "/tmp/key.pem", "k6 version", provider: :oci)
+
+      assert Enum.at(argv, 6) === "ubuntu@1.2.3.4"
+    end
+
+    test "expands a relative pem path" do
+      argv = Exec.ssh_args("1.2.3.4", "key.pem", "k6 version", [])
+
+      assert Enum.at(argv, 1) === Path.expand("key.pem")
+    end
+  end
+
   describe "build_k6_command/3" do
     test "includes TARGET_URL and K6_PROMETHEUS_RW_SERVER_URL with the -o flag when both are configured" do
       command = Exec.build_k6_command("load_test.js", "http://10.0.101.171:9090", "http://app:4000")

--- a/test/mix/tasks/deploy_ex_load_test_exec_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_exec_test.exs
@@ -103,6 +103,16 @@ defmodule Mix.Tasks.DeployEx.LoadTest.ExecTest do
     end
   end
 
+  describe "ssh_target/2 — SSH user via Cloud.ssh_user/1 (LT-OCI S1)" do
+    test "defaults to admin@ip under the AWS provider (unchanged AWS behavior)" do
+      assert Exec.ssh_target("1.2.3.4", []) === "admin@1.2.3.4"
+    end
+
+    test "resolves ubuntu@ip for an overridden provider" do
+      assert Exec.ssh_target("1.2.3.4", provider: :oci) === "ubuntu@1.2.3.4"
+    end
+  end
+
   describe "build_k6_command/3" do
     test "includes TARGET_URL and K6_PROMETHEUS_RW_SERVER_URL with the -o flag when both are configured" do
       command = Exec.build_k6_command("load_test.js", "http://10.0.101.171:9090", "http://app:4000")

--- a/test/mix/tasks/deploy_ex_load_test_exec_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_exec_test.exs
@@ -104,8 +104,15 @@ defmodule Mix.Tasks.DeployEx.LoadTest.ExecTest do
   end
 
   describe "discover_prometheus_ip/1 — threads opts through Cloud.capability (LT-OCI review-fix)" do
-    test "an unregistered/unimplemented provider override propagates instead of being dropped" do
-      assert {:error, %ErrorMessage{code: :not_implemented}} = Exec.discover_prometheus_ip(provider: :oci)
+    test "an unregistered provider override propagates instead of being dropped" do
+      assert {:error, %ErrorMessage{code: :not_implemented}} = Exec.discover_prometheus_ip(provider: :gcp)
+    end
+
+    test "under :oci (machine wired as of LT-OCI S2), a config error propagates instead of falling through to AWS" do
+      assert {:error, %ErrorMessage{code: :bad_request, message: message}} =
+               Exec.discover_prometheus_ip(provider: :oci)
+
+      assert message =~ "compartment_id"
     end
   end
 

--- a/test/mix/tasks/deploy_ex_load_test_exec_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_exec_test.exs
@@ -103,6 +103,12 @@ defmodule Mix.Tasks.DeployEx.LoadTest.ExecTest do
     end
   end
 
+  describe "discover_prometheus_ip/1 — threads opts through Cloud.capability (LT-OCI review-fix)" do
+    test "an unregistered/unimplemented provider override propagates instead of being dropped" do
+      assert {:error, %ErrorMessage{code: :not_implemented}} = Exec.discover_prometheus_ip(provider: :oci)
+    end
+  end
+
   describe "ssh_target/2 — SSH user via Cloud.ssh_user/1 (LT-OCI S1)" do
     test "defaults to admin@ip under the AWS provider (unchanged AWS behavior)" do
       assert Exec.ssh_target("1.2.3.4", []) === "admin@1.2.3.4"

--- a/test/mix/tasks/deploy_ex_load_test_upload_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_upload_test.exs
@@ -45,6 +45,41 @@ defmodule Mix.Tasks.DeployEx.LoadTest.UploadTest do
     end
   end
 
+  describe "scp_args/5 — pure scp argv builder, pins the actual upload_script call site (LT-OCI review-fix)" do
+    test "builds the exact scp argv under the default AWS provider" do
+      assert Upload.scp_args("/tmp/key.pem", "/local/load_test.js", "1.2.3.4", "/srv/k6/scripts/load_test.js", []) ===
+               [
+                 "-i",
+                 "/tmp/key.pem",
+                 "-o",
+                 "StrictHostKeyChecking=no",
+                 "-o",
+                 "UserKnownHostsFile=/dev/null",
+                 "/local/load_test.js",
+                 "admin@1.2.3.4:/srv/k6/scripts/load_test.js"
+               ]
+    end
+
+    test "resolves the ssh user through Cloud.ssh_user/1 for an overridden provider" do
+      argv =
+        Upload.scp_args(
+          "/tmp/key.pem",
+          "/local/load_test.js",
+          "1.2.3.4",
+          "/srv/k6/scripts/load_test.js",
+          provider: :oci
+        )
+
+      assert Enum.at(argv, 7) === "ubuntu@1.2.3.4:/srv/k6/scripts/load_test.js"
+    end
+
+    test "expands a relative pem path" do
+      argv = Upload.scp_args("key.pem", "/local/load_test.js", "1.2.3.4", "/srv/k6/scripts/load_test.js", [])
+
+      assert Enum.at(argv, 1) === Path.expand("key.pem")
+    end
+  end
+
   describe "resolve_runner/2 default path (no --instance-id)" do
     test "returns a not_found error naming create_instance when the only runner is terminated" do
       assert {:error, %ErrorMessage{code: :not_found, message: message}} =

--- a/test/mix/tasks/deploy_ex_load_test_upload_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_upload_test.exs
@@ -6,19 +6,19 @@ defmodule Mix.Tasks.DeployEx.LoadTest.UploadTest do
   defmodule FakeK6RunnerTerminated do
     def fetch_all_runners(_opts), do: {:ok, [%DeployEx.K6Runner{instance_id: "i-dead"}]}
     def fetch_state(_instance_id, _opts), do: {:ok, %DeployEx.K6Runner{instance_id: "i-dead"}}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
   end
 
   defmodule FakeK6RunnerAbsent do
     def fetch_all_runners(_opts), do: {:ok, []}
     def fetch_state(_instance_id, _opts), do: {:ok, nil}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
   end
 
   defmodule FakeK6RunnerFetchYieldsNil do
     def fetch_all_runners(_opts), do: {:ok, nil}
     def fetch_state(_instance_id, _opts), do: {:ok, nil}
-    def verify_instance_exists(_runner), do: {:ok, nil}
+    def verify_instance_exists(_runner, _opts \\ []), do: {:ok, nil}
   end
 
   defmodule FakeK6RunnerActive do
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.DeployEx.LoadTest.UploadTest do
       {:ok, %DeployEx.K6Runner{instance_id: "i-live", public_ip: "1.2.3.4"}}
     end
 
-    def verify_instance_exists(runner), do: {:ok, %{runner | state: "running"}}
+    def verify_instance_exists(runner, _opts \\ []), do: {:ok, %{runner | state: "running"}}
   end
 
   describe "scp_target/3 — SSH user via Cloud.ssh_user/1 (LT-OCI S1)" do

--- a/test/mix/tasks/deploy_ex_load_test_upload_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_upload_test.exs
@@ -33,6 +33,18 @@ defmodule Mix.Tasks.DeployEx.LoadTest.UploadTest do
     def verify_instance_exists(runner), do: {:ok, %{runner | state: "running"}}
   end
 
+  describe "scp_target/3 — SSH user via Cloud.ssh_user/1 (LT-OCI S1)" do
+    test "defaults to admin@ip:path under the AWS provider (unchanged AWS behavior)" do
+      assert Upload.scp_target("1.2.3.4", "/srv/k6/scripts/load_test.js", []) ===
+               "admin@1.2.3.4:/srv/k6/scripts/load_test.js"
+    end
+
+    test "resolves ubuntu@ip:path for an overridden provider" do
+      assert Upload.scp_target("1.2.3.4", "/srv/k6/scripts/load_test.js", provider: :oci) ===
+               "ubuntu@1.2.3.4:/srv/k6/scripts/load_test.js"
+    end
+  end
+
   describe "resolve_runner/2 default path (no --instance-id)" do
     test "returns a not_found error naming create_instance when the only runner is terminated" do
       assert {:error, %ErrorMessage{code: :not_found, message: message}} =


### PR DESCRIPTION
## What

Adapts the k6 load-testing workflow to run on Oracle Cloud through the `DeployEx.Cloud` provider seam. Stacked on #21 (`feat/oci-multi-cloud`) — review/merge that one first.

Before this change the entire load-test surface bypassed the seam and called `ExAws.EC2`/`ExAws.S3`/`DeployEx.Config.aws_*` directly with a hardcoded `admin` SSH user, so it only worked on AWS. After it, the same tasks run on either provider via `--provider oci` (or `config :deploy_ex, :cloud_provider`), and OCI gains a real compute implementation.

## Sprints

**S1 — route the load-test surface through the Cloud seam.** K6Runner state ops go through `Cloud.capability(:object_store)`; machine ops (run/terminate/describe/list/await) through `Cloud.capability(:machine)`; config reads through the provider descriptor; the SSH user through `DeployEx.Cloud.ssh_user/1` at all four previously-hardcoded sites. AWS behavior is unchanged — the full existing suite plus the adversarial oracle stay green with no edits to their expectations.

**S2 — OciMachine + OciInfrastructure.** `OciMachine` launches/terminates/gets/lists instances via `oci compute instance …` in the configured compartment, tags them for K6Runner/MonitoringKey discovery, waits for `RUNNING`, and resolves the address from the primary VNIC. `OciInfrastructure` resolves subnet/image from config keys (`subnet_id`, `base_image`). The OCI descriptor's `machine:` and `infrastructure:` slots are filled and `cli_adapter` set. All unit tests inject `run_fn` — no live calls in the suite.

**S3 — live verification on real OCI.** Verified end-to-end against a real tenancy (ap-seoul-1), driving the seam's own code paths:

- `K6Runner.create_instance` → `OciMachine.run_instance` issued a real `oci compute instance launch`; `await_running` reached `RUNNING`; `describe_instance` returned the instance with its public IP, `running` state, and K6Runner tags; the SSH user resolved to `ubuntu`.
- The runner's own user_data installed k6 (`v2.2.0`, `linux/arm64`); SSH + key auth succeeded.
- A 1-VU / 30s k6 run against a runner-local target (no external traffic), issued with the seam's exact `k6 run /srv/k6/scripts/…` command, reported 30/30 checks succeeded, 0 failed requests.
- The no-Prometheus path: `resolve_prometheus_url` returns `nil` on OCI (no Prometheus node exists there), and `build_k6_command` emits a Prometheus-free command, so the "running without metrics export" warning fires as intended.
- Teardown through the seam: `terminate_instance` → `:ok`; `list_instances([{"K6Runner","true"}])` drained to zero live instances.

The live run used an isolated throwaway VCN created only for the test and fully torn down afterward; no pre-existing infrastructure was modified.

## Fix included: arm64 runners

OCI's Always-Free compute shape is ARM (`VM.Standard.A1.Flex`), but `build_user_data` installed k6 from the `dl.k6.io/deb` apt repository, which publishes amd64 only — so `apt-get install k6` fails with "Unable to locate package k6" on ARM. `build_user_data` is now architecture-aware: arm64 hosts install k6's official `linux-arm64` release binary (pinned), and amd64 keeps the apt path byte-for-byte so AWS runners are unaffected. Covered by tests for both branches.

## Tests

`mix test` — 1101 tests, 0 failures. AWS-path invariance is pinned by the untouched existing suite and the k6_runner adversarial oracle.

## Notes

- On OCI there is no Prometheus node, so k6 runs without remote-write (by design); metrics export remains available on AWS and via an explicit `--prometheus-url`.
- OCI live steps require an active `oci` session (`--auth security_token`, e.g. profile `opgg`); the failure mode on an expired session is a loud auth error, not a silent skip.
