### PR TITLE
fix(aws_autoscaling): map AWS's "name not found" to :not_found

### DIFF
--- a/lib/deploy_ex/aws_autoscaling.ex
+++ b/lib/deploy_ex/aws_autoscaling.ex
@@ -42,6 +42,7 @@ defmodule DeployEx.AwsAutoscaling do
 
   def set_desired_capacity(asg_name, desired_capacity, opts \\ []) do
     region = opts[:region] || DeployEx.Config.aws_region()
+    request_fn = opts[:request_fn] || (&ExAws.request/2)
 
     %ExAws.Operation.Query{
       path: "/",
@@ -53,7 +54,7 @@ defmodule DeployEx.AwsAutoscaling do
       },
       service: :autoscaling
     }
-    |> ExAws.request(region: region)
+    |> request_fn.(region: region)
     |> handle_set_capacity_response()
   end
 
@@ -68,6 +69,7 @@ defmodule DeployEx.AwsAutoscaling do
       )}
     else
       region = opts[:region] || DeployEx.Config.aws_region()
+      request_fn = opts[:request_fn] || (&ExAws.request/2)
 
       params = %{
         "Action" => "StartInstanceRefresh",
@@ -82,7 +84,7 @@ defmodule DeployEx.AwsAutoscaling do
         params: params,
         service: :autoscaling
       }
-      |> ExAws.request(region: region)
+      |> request_fn.(region: region)
       |> handle_start_refresh_response()
     end
   end
@@ -244,7 +246,7 @@ defmodule DeployEx.AwsAutoscaling do
       String.contains?(body, "ValidationError") and String.contains?(body, "outside") ->
         {:error, ErrorMessage.bad_request("desired capacity outside min/max range")}
 
-      String.contains?(body, "does not exist") ->
+      asg_missing?(body) ->
         {:error, ErrorMessage.not_found("autoscaling group not found")}
 
       true ->
@@ -275,7 +277,7 @@ defmodule DeployEx.AwsAutoscaling do
       String.contains?(body, "InstanceRefreshInProgress") ->
         {:error, ErrorMessage.conflict("instance refresh already in progress")}
 
-      String.contains?(body, "does not exist") ->
+      asg_missing?(body) ->
         {:error, ErrorMessage.not_found("autoscaling group not found")}
 
       true ->
@@ -289,6 +291,11 @@ defmodule DeployEx.AwsAutoscaling do
 
   defp handle_start_refresh_response({:error, error}) do
     {:error, ErrorMessage.failed_dependency("AWS request failed", %{error: inspect(error)})}
+  end
+
+  # AWS says "AutoScalingGroup name not found - null" for a missing group
+  defp asg_missing?(body) do
+    String.contains?(body, "name not found") or String.contains?(body, "does not exist")
   end
 
   defp handle_describe_refreshes_response({:ok, %{body: body}}) do

--- a/test/deploy_ex/aws_autoscaling_test.exs
+++ b/test/deploy_ex/aws_autoscaling_test.exs
@@ -1,0 +1,29 @@
+defmodule DeployEx.AwsAutoscalingTest do
+  use ExUnit.Case, async: true
+
+  alias DeployEx.AwsAutoscaling
+
+  # Real AWS body for a missing group — it says "name not found - null", not "does not exist".
+  @missing_asg_body """
+  <ErrorResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
+    <Error>
+      <Type>Sender</Type>
+      <Code>ValidationError</Code>
+      <Message>AutoScalingGroup name not found - null</Message>
+    </Error>
+    <RequestId>1aa2e3b2-a483-42d2-9dda-d7a8182ed6e1</RequestId>
+  </ErrorResponse>
+  """
+
+  defp missing_asg(_operation, _opts), do: {:error, {:http_error, 400, %{body: @missing_asg_body}}}
+
+  test "start_instance_refresh maps AWS's 'name not found' to :not_found" do
+    assert {:error, %ErrorMessage{code: :not_found}} =
+             AwsAutoscaling.start_instance_refresh("missing-asg-prod", %{}, request_fn: &missing_asg/2)
+  end
+
+  test "set_desired_capacity maps AWS's 'name not found' to :not_found" do
+    assert {:error, %ErrorMessage{code: :not_found}} =
+             AwsAutoscaling.set_desired_capacity("missing-asg-prod", 1, request_fn: &missing_asg/2)
+  end
+end


### PR DESCRIPTION
## Summary
- AWS returns "AutoScalingGroup name not found - null" for a missing group, but both error handlers matched the string "does not exist", so a missing ASG never mapped to `:not_found`.
- Adds an `asg_missing?/1` helper covering the real response body, and a `request_fn` injection seam on `set_desired_capacity` and `start_instance_refresh` so both paths are testable without live AWS.

This commits pre-existing, already-written work (not authored on this lane) onto a fresh branch off `origin/main`.

## Test plan
- `mix test` on this branch: 699 tests, 0 failures (single run, not independently re-verified beyond this).

**Do not merge.** Merging is gated separately.

## Verified on the merged tree, not on the branch

`main` moved three times after this branch was cut — `c7eb370`, `22accfc`, `975c5d3` — so the branch's own numbers describe a tree that no longer exists. Re-run on `origin/main` + this branch in a clean single-toolchain worktree:

- `git merge --squash` → clean, "Automatic merge went well"
- `mix compile --warnings-as-errors` → **exit 0**
- `mix test` → **708 tests, 0 failures**. Ties: 697 baseline + 4 + 2 + 3 = 706, + 2 (this) = 708.

## Provider classification

**Non-OCI.** `lib/deploy_ex/aws_autoscaling.ex` is an AWS-only module with no counterpart on the OCI provider path; the OCI seam on `opgginc/deploy_ex@main` overrides `deploy_node` and `oci_cli` only and has no autoscaling module at all. Nothing here is reachable from a non-AWS render.
