### PR TITLE
fix(ansible): serve self-hosted Sentry on port 80, keep sentry_url in agreement

### DIFF
--- a/guides/how-to/monitoring.md
+++ b/guides/how-to/monitoring.md
@@ -180,17 +180,17 @@ Disk usage under `errors-only` is meaningfully lower than `feature-complete` (fe
 
 ### Access — private VPC only
 
-The Sentry web service binds to the node's private VPC address (`SENTRY_BIND` in `.env`, not `127.0.0.1`) — see the security group note below for what that does and doesn't protect. There is no public exposure and no Let's Encrypt cert this cycle.
+The Sentry web service binds to the node's private VPC address (`SENTRY_BIND` in `.env`, not `127.0.0.1`) — see the security group note below for what that does and doesn't protect, **which changed when the default port moved to 80.** There is no Let's Encrypt cert this cycle.
 
 ```bash
 mix deploy_ex.ssh.authorize                              # allowlist your IP for SSH (port 22 is allowlist-only)
 mix deploy_ex.find_nodes --tag MonitoringKey=sentry       # find the node's IP
-ssh -i deploys/terraform/*.pem -L 9000:<sentry-node-ip>:9000 admin@<sentry-node-ip>
+ssh -i deploys/terraform/*.pem -L 9000:<sentry-node-ip>:80 admin@<sentry-node-ip>
 ```
 
-The `-L` remote address (the node's own bound VPC address, on port 9000) is resolved by the SSH server (the sentry node), not your machine. Then browse `http://localhost:9000` locally. `group_vars/all.yaml`'s `sentry_url` is the same address — it's what the Sentry container uses to build links back to the UI, and is also what the tunnel targets.
+The `-L` remote address (the node's own bound VPC address, on port 80 — the shipped default) is resolved by the SSH server (the sentry node), not your machine; the local port (`9000` above) is arbitrary and only needs to avoid clashing with something else on your machine (ports below 1024 need root to bind locally, so picking an unprivileged local port like `9000` while forwarding to the node's real port 80 avoids that). Then browse `http://localhost:9000` locally. `group_vars/all.yaml`'s `sentry_url` is the same address — it's what the Sentry container uses to build links back to the UI, and is also what the tunnel targets.
 
-**Security group note:** a freshly-generated deploy_ex security group has no rule allowing traffic between members of the group itself, and no rule for port 9000 — only `http-80-tcp`/`https-443-tcp` from `0.0.0.0/0` plus the dynamic SSH allowlist. cfx's live security group currently has an all-protocol self-referencing rule (infrastructure drift, not shipped by these templates) which is why the tunnel already works there. New consumers need an equivalent intra-SG (or port-9000-scoped) ingress rule added by hand — **this sprint does not template any security group change.**
+**Security group note — changed by the `sentry_web_port` 9000→80 default:** deploy_ex's shared `app_security_group` (`priv/terraform/network.tf`) opens `http-80-tcp`/`https-443-tcp` to `0.0.0.0/0` and `::/0` for *every* instance in the group — monitoring nodes included — and `sentry`'s own terraform block ships `enable_eip = true` in a public subnet. While `sentry_web_port` defaulted to 9000, that open 80/443 rule never reached Sentry (no ingress rule matched 9000), so the "private VPC only, SSH tunnel" model above held in practice despite the wide-open rule existing. **Now that the default is 80, `SENTRY_BIND` lands on the same port the shared security group already opens to the entire internet** — a consumer applying this default to a live node gets the Sentry UI reachable over the public internet on port 80, not gated by the SSH-tunnel model described above. This lane's port change is template-defaults-only and does **not** template a security-group carve-out for it. Before applying this default to any live node, add an explicit restriction (move `sentry` off the shared web security group, or add a deny/scope rule ahead of the `0.0.0.0/0` allow) — **do not rely on the "private VPC only" framing above once the port is 80.**
 
 If the node isn't running:
 

--- a/priv/ansible/group_vars/all.yaml.eex
+++ b/priv/ansible/group_vars/all.yaml.eex
@@ -32,7 +32,7 @@ prometheus_retention_time: 7d
 #   mix deploy_ex.find_nodes --tag MonitoringKey=sentry
 # Only sets system.url-prefix (UI link-building); the container binds to the
 # node's own address via SENTRY_BIND regardless, and ingest uses the DSN.
-sentry_url: "http://FILL_IN_AFTER_FIRST_APPLY:9000"
+sentry_url: "http://FILL_IN_AFTER_FIRST_APPLY:80"
 <% end %>
 system_env:
   - PATH=/root/.asdf/shims:/root/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/priv/ansible/roles/sentry_server/defaults/main.yaml
+++ b/priv/ansible/roles/sentry_server/defaults/main.yaml
@@ -13,7 +13,7 @@ sentry_install_dir: /opt/sentry-self-hosted
 sentry_data_device: /dev/nvme1n1
 sentry_data_dir: /mnt/sentry-data
 
-sentry_web_port: 9000
+sentry_web_port: 80
 
 # getsentry/self-hosted ships this as a plaintext default in its committed
 # .env (x-sentry-defaults). Inert under errors-only (launchpad only runs

--- a/test/deploy_ex/priv_renderer_test.exs
+++ b/test/deploy_ex/priv_renderer_test.exs
@@ -154,7 +154,7 @@ defmodule DeployEx.PrivRendererTest do
 
       # DHCP (IP-FIX): the sentry node's IP is not known at render time, so
       # sentry_url renders as a FILL_IN placeholder like grafana_{loki,prometheus,mimir}_url.
-      assert group_vars_content =~ ~s(sentry_url: "http://FILL_IN_AFTER_FIRST_APPLY:9000")
+      assert group_vars_content =~ ~s(sentry_url: "http://FILL_IN_AFTER_FIRST_APPLY:80")
     end
 
     test "group_vars/all.yaml omits sentry_url when no_sentry: true" do

--- a/test/deploy_ex/sentry_web_port_test.exs
+++ b/test/deploy_ex/sentry_web_port_test.exs
@@ -1,0 +1,74 @@
+defmodule DeployEx.SentryWebPortTest do
+  use ExUnit.Case, async: true
+
+  alias DeployEx.PrivRenderer
+
+  # priv/ansible/roles/sentry_server/defaults/main.yaml pins the port Sentry's
+  # container binds to (SENTRY_BIND in env.j2, and the role's own health check
+  # in tasks/main.yaml). priv/ansible/group_vars/all.yaml.eex pins the
+  # system.url-prefix placeholder every fresh consumer sees before their first
+  # `mix terraform.apply`. The two used to agree at 9000; this suite pins both
+  # at 80 AND pins that they agree with each other, so a future change to only
+  # one of them fails loudly instead of silently reintroducing the mismatch.
+
+  @sentry_role_dir Path.expand("../../priv/ansible/roles/sentry_server", __DIR__)
+  @sentry_defaults_path Path.join(@sentry_role_dir, "defaults/main.yaml")
+
+  defp sentry_web_port do
+    @sentry_defaults_path
+    |> YamlElixir.read_from_file!()
+    |> Map.fetch!("sentry_web_port")
+  end
+
+  defp render_group_vars(opts \\ []) do
+    {:ok, temp_dir} = PrivRenderer.render_to_temp(Keyword.put_new(opts, :environment, "dev"))
+    on_exit(fn -> File.rm_rf!(temp_dir) end)
+    File.read!(Path.join(temp_dir, "ansible/group_vars/all.yaml"))
+  end
+
+  defp sentry_url_from(group_vars_content) do
+    [_, url] = Regex.run(~r/^sentry_url: "(.+)"$/m, group_vars_content)
+    url
+  end
+
+  # SECTION: D1 — sentry_server role default
+
+  describe "sentry_server role default — sentry_web_port" do
+    test "defaults to 80" do
+      assert sentry_web_port() === 80
+    end
+  end
+
+  # SECTION: D2 — paired group_vars placeholder
+
+  describe "sentry_url group_vars placeholder" do
+    test "renders with port 80, FILL_IN_AFTER_FIRST_APPLY untouched" do
+      content = render_group_vars()
+
+      assert sentry_url_from(content) === "http://FILL_IN_AFTER_FIRST_APPLY:80"
+    end
+  end
+
+  # SECTION: Done criterion 4 — the agreement test
+
+  describe "sentry_url and sentry_web_port stay in agreement" do
+    test "sentry_url's rendered port equals sentry_web_port's default" do
+      content = render_group_vars()
+      rendered_port = content |> sentry_url_from() |> URI.parse() |> Map.fetch!(:port)
+
+      assert rendered_port === sentry_web_port()
+    end
+  end
+
+  # SECTION: behavioural — SENTRY_BIND and the health check key off the same variable
+
+  describe "env.j2 SENTRY_BIND and the role's own health check" do
+    test "both interpolate {{ sentry_web_port }} — they cannot independently drift" do
+      env_content = File.read!(Path.join(@sentry_role_dir, "templates/env.j2"))
+      tasks_content = File.read!(Path.join(@sentry_role_dir, "tasks/main.yaml"))
+
+      assert env_content =~ "SENTRY_BIND={{ ansible_default_ipv4.address }}:{{ sentry_web_port }}"
+      assert tasks_content =~ "http://{{ ansible_default_ipv4.address }}:{{ sentry_web_port }}/_health/"
+    end
+  end
+end

--- a/test/support/fixtures/mimir/baseline_group_vars_all.yaml
+++ b/test/support/fixtures/mimir/baseline_group_vars_all.yaml
@@ -32,7 +32,7 @@ prometheus_retention_time: 7d
 #   mix deploy_ex.find_nodes --tag MonitoringKey=sentry
 # Only sets system.url-prefix (UI link-building); the container binds to the
 # node's own address via SENTRY_BIND regardless, and ingest uses the DSN.
-sentry_url: "http://FILL_IN_AFTER_FIRST_APPLY:9000"
+sentry_url: "http://FILL_IN_AFTER_FIRST_APPLY:80"
 
 system_env:
   - PATH=/root/.asdf/shims:/root/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
## Summary
- `sentry_web_port` (role default) and `sentry_url`'s placeholder port (`group_vars/all.yaml.eex`) were consistent at 9000. Moving only the role default would have shipped self-contradicting defaults — Sentry binds `:80` while `system.url-prefix` tells clients `:9000`, and the role's own health check follows `sentry_web_port`, so it stays green while every generated DSN points at a dead port. This changes both, to 80.
- Adds a test asserting `sentry_url`'s rendered port *agrees with* `sentry_web_port` (not that each equals 80 — an agreement assertion catches future drift on either side, a value pin would not).
- Updates the two pre-existing tests whose fixtures hardcoded the old 9000 placeholder.
- Updates `guides/how-to/monitoring.md`'s SSH-tunnel port and its security-group note: the shared `app_security_group` already opens 80/443 to `0.0.0.0/0` for every instance including monitoring nodes, and `sentry` ships `enable_eip = true` in a public subnet. At 9000 that open rule never reached Sentry; at 80 it does. **This PR does not template a security-group carve-out for that** — flagged in the guide as a follow-up before any live node applies this default.

## Test plan
- [x] `mix compile --warnings-as-errors` — exit 0
- [x] `mix test` — 701 tests, 0 failures (baseline 697 + 4 new)
- [x] New pinning tests (`sentry_web_port` = 80, rendered `sentry_url` port = 80, and the two agree) each verified RED before the fix and RED again under a mutation-arm revert of either side
- [x] Render-diff: full `PrivRenderer.render_to_temp` output before/after this change differs only in the two touched lines (`ansible/group_vars/all.yaml`, `ansible/roles/sentry_server/defaults/main.yaml`); a third file (`terraform/key-pair-main.tf`) differs but is confirmed pre-existing per-run randomness, not caused by this change
- [x] `git log --merges` — empty

## Provider classification — measured, not derived

This change is **non-OCI**: it cannot alter OCI-rendered output.

The obvious check — "render with both providers, show byte-identical output" — is degenerate on this repository's `main`, because `main` has no provider seam at all (`#20` landed as `7f32bf8` and was reverted by `e06649a`). A check whose failure mode you cannot state is not a check, and on a seam-less base the honest answer to "what would this have caught?" is "nothing — there is one code path."

So the claim was verified against the branch that *does* carry a working OCI provider seam, `opgginc/deploy_ex@main` (`ef98382`):

| check | result | control |
|---|---|---|
| `sentry` files present in the OCI-seam tree | **0** | same command on this repo's `main` returns **4** (`roles/sentry_server/{defaults,tasks,templates/env.j2}`, `setup/sentry.yaml`) |
| `sentry`/`9000` keys in the OCI provider's `group_vars/all.yaml.eex` override | **none** | same grep shape in the same file finds `grafana_loki_url`, `loki_logger_*`, `grafana_prometheus_url` |
| roles overridden on the OCI ansible path | `deploy_node`, `oci_cli` only | — |

Both files this PR touches are AWS-path / shared-default, and the role they configure does not exist on the OCI seam. The check could have failed — a `sentry_server` role or a `sentry_url` key on that path would have surfaced in either grep — and it did not.

## Follow-up, not fixed here

The shared `app_security_group` in `priv/terraform/network.tf` opens `http-80-tcp`/`https-443-tcp` to `0.0.0.0/0` and `::/0` for **every** instance deploy_ex renders, with the restrictive form (`ingress_cidr_blocks = module.vpc.public_subnets_cidr_blocks`) commented out immediately beside it and a `description` whose stated scope ("within VPC") contradicts the rule as written. This is **pre-existing** and is not introduced or widened by this PR — but moving Sentry to port 80 is what makes it reachable, which is why the guide note in this PR calls it out. Tracked separately; owner: `project-deploy-ex-observability`. It does not ride along with this merge.
