### PR TITLE
fix(grafana_alloy): make the app metrics scrape port configurable

### DIFF
--- a/priv/ansible/roles/grafana_alloy/defaults/main.yaml
+++ b/priv/ansible/roles/grafana_alloy/defaults/main.yaml
@@ -1,3 +1,4 @@
 alloy_version: v1.9.0
 alloy_architecture: linux-amd64
+alloy_app_metrics_port: 4050
 extra_alloy_env: []

--- a/priv/ansible/roles/grafana_alloy/templates/alloy_config.alloy.j2
+++ b/priv/ansible/roles/grafana_alloy/templates/alloy_config.alloy.j2
@@ -67,7 +67,7 @@ prometheus.scrape "node_exporter" {
 prometheus.scrape "app" {
   job_name = "apps"
   targets = [{
-    "__address__" = "localhost:4050",
+    "__address__" = "localhost:{{ alloy_app_metrics_port }}",
     "instance"    = "{{ inventory_hostname }}",
     "instance_id" = "{{ instance_id | default('unknown') }}",
   }]

--- a/test/deploy_ex/mimir_role_test.exs
+++ b/test/deploy_ex/mimir_role_test.exs
@@ -144,6 +144,7 @@ defmodule DeployEx.MimirRoleTest do
 
   describe "alloy_config.alloy.j2 — metrics pipeline" do
     @alloy_path Path.join(@priv_roles_dir, "grafana_alloy/templates/alloy_config.alloy.j2")
+    @alloy_defaults_path Path.join(@priv_roles_dir, "grafana_alloy/defaults/main.yaml")
 
     test "scrapes node_exporter and app metrics locally, remote_writes to Mimir, no ec2_sd" do
       content = File.read!(@alloy_path)
@@ -151,10 +152,32 @@ defmodule DeployEx.MimirRoleTest do
       assert content =~ "{% if grafana_mimir_url is defined %}"
       assert content =~ "localhost:9100"
       assert content =~ "{% if app_name is defined %}"
-      assert content =~ "localhost:4050"
+      assert content =~ "localhost:{{ alloy_app_metrics_port }}"
       assert content =~ ~s(prometheus.remote_write "mimir")
       assert content =~ "{{ grafana_mimir_url }}"
       refute content =~ "ec2_sd"
+    end
+
+    # The app scrape port used to be the literal `4050` — every consumer whose apps
+    # expose metrics on a different port got a Mimir that looked healthy (node_exporter
+    # metrics flow fine) while receiving zero application metrics. `alloy_app_metrics_port`
+    # is now a role default (grafana_alloy/defaults/main.yaml), and the template reads it
+    # bare — no `| default(4050)` filter — because a role default is always in scope when
+    # the role renders its own template; a filter would just be a second, driftable copy
+    # of the same number.
+    test "the app scrape port is the alloy_app_metrics_port variable, read bare with no default() filter" do
+      content = File.read!(@alloy_path)
+
+      assert content =~ ~s("__address__" = "localhost:{{ alloy_app_metrics_port }}",)
+      refute content =~ "alloy_app_metrics_port | default"
+      refute content =~ "alloy_app_metrics_port|default"
+      refute content =~ "localhost:4050"
+    end
+
+    test "defaults/main.yaml declares alloy_app_metrics_port: 4050 (the single source of truth)" do
+      content = File.read!(@alloy_defaults_path)
+
+      assert content =~ "alloy_app_metrics_port: 4050"
     end
 
     test "the journal relabel rule's app_name reference defaults instead of crashing monitoring-node plays" do


### PR DESCRIPTION
## Summary

`alloy_config.alloy.j2` scraped the app metrics target at the literal `localhost:4050`.
Any consumer whose apps expose metrics on a different port gets a Mimir that looks fully
healthy (node_exporter still flows on the correct `9100`, the datasource goes green, node
dashboards render) while receiving zero application metrics.

- Add `alloy_app_metrics_port: 4050` to `roles/grafana_alloy/defaults/main.yaml`.
- Template now reads `{{ alloy_app_metrics_port }}` bare, with no `| default(4050)` filter —
  a role default is always in scope when the role renders its own template, so the filter
  would be dead code and a second, driftable copy of the same number.

`localhost:9100` (node_exporter) and the `{% if grafana_mimir_url is defined %}` gating are
untouched — out of scope.

## Test plan

- Extended `test/deploy_ex/mimir_role_test.exs`'s existing `alloy_config.alloy.j2 — metrics
  pipeline` describe block (found via `grep -rl alloy_config test/`) rather than adding a
  parallel test file.
- New/updated structural assertions on the raw template + role defaults, TDD RED before the
  fix, GREEN after, and RED again on a manual revert of the template line (mutation arm).
- `mix test`: 699 tests, 0 failures (baseline 697 + 2 new tests).
- `mix compile --warnings-as-errors`: exit 0 (dev and test envs).
- Manually rendered the template with `ansible-playbook`/real Jinja2 (default case, override
  case, and against a reverted template) as evidence that the actual resolved config text
  behaves as expected — that render path isn't a committed `mix test` dependency, matching
  the precedent already established in this same test file for Ansible/Jinja content.
- Rendered before/after the change with no live provider seam existing on `main` (confirmed
  via grep — `cloud_provider`/`--provider` don't exist here); all renders byte-identical.

No merge commits in this branch.

## Provider classification — measured, and the vacuous version named

**Non-OCI.** This is a provider-agnostic change to a *shared* ansible role: it removes a hardcoded port from `grafana_alloy`, which predates the provider seam and is read identically by every provider.

The naive fence check — "render with both providers, show byte-identical output" — is **vacuous here by construction**, and worth saying so rather than quoting it as a pass: there is one template, both providers read it, so identical output is guaranteed regardless of what this PR does. A check whose failure mode you cannot state is not a check.

The check that *can* fail is whether `grafana_alloy` has a provider-specific override that this change would cause to diverge. Run against `opgginc/deploy_ex@main` (`ef98382`), the only ref carrying a working OCI provider seam:

| check | result | control |
|---|---|---|
| roles overridden on the OCI ansible path | `deploy_node`, `oci_cli` — **`grafana_alloy` is not among them** | the same path grep returns **5** files for `deploy_node`, so it discriminates |

An override existing would have surfaced. None does, so there is a single shared template and no provider-divergent behaviour to introduce.

## Verified on the merged tree, not on the branch

`main` moved to `c7eb370` (the Sentry port merge) after this PR's head was cut, so the branch's own numbers no longer describe what merging produces. Re-run on `origin/main` + this commit, in a clean worktree that has never seen a second toolchain (erlang 27.3 / elixir 1.17.3-otp-27 per `.tool-versions`):

- `mix compile --warnings-as-errors` → **exit 0**
- `mix test` → **703 tests, 0 failures**. Ties: 697 baseline + 4 (Sentry) = 701, + 2 (this PR) = 703.
- No file overlap with the Sentry merge; cherry-pick applied clean.

## Known limitation, stated so it is not mistaken for a fix

This makes the scrape port configurable **on this repository's `main` only**. The same literal does not exist on `opgginc/deploy_ex@main`, whose `grafana_alloy` is logs-only with no metrics pipeline at all, so this commit would be inert there and must not be cherry-picked across — the pipeline has to be ported first, carrying the variable with it.

Separately: the block this port sits inside is gated on `{% if grafana_mimir_url is defined %}`, and that variable ships as the sentinel `"http://FILL_IN_AFTER_FIRST_APPLY:8080"`. Presence is therefore not validity — a consumer that defines it without filling it in renders a `prometheus.remote_write` pointed at a placeholder host. That gate predicate is a pre-existing design question, is **not** addressed here, and is tracked separately.
