### PR TITLE
feat(oci): re-land the block volume, provider-aware Mimir

### DIFF
--- a/guides/how-to/replacing_prometheus_with_mimir.md
+++ b/guides/how-to/replacing_prometheus_with_mimir.md
@@ -40,6 +40,16 @@ deploy_ex-managed project (not starting fresh), re-running `mix terraform.build`
 secondary EBS volume to your Terraform plan (roughly $17/mo at on-demand rates) —
 review the plan before applying, or pass `--no-mimir` to opt out until you're ready.
 
+**On OCI** (`mix terraform.build --provider oci`): Mimir renders as a
+`VM.Standard.E5.Flex` instance (1 OCPU / 4GB) with an opt-in **Block Volume**
+(paravirtualized attachment, 50GB, mounted at `/data` via cloud-init) instead of AWS's
+secondary EBS volume — OCI has no equivalent of AWS's cloud-init-driven app deploy, so
+the OCI-side cloud-init payload does only the block-volume format-and-mount, nothing
+else. Same `MonitoringKey = "mimir_db"` tag, same `--no-mimir` opt-out. The block
+volume is generic opt-in infrastructure on the `oci-instance` module (`enable_block_volume`
+/ `block_volume_size_gbs`, or `block_volume = { enable, size_gbs }` on a per-app
+project entry) — Mimir is simply its first consumer.
+
 **Delivery to existing `./deploys/` trees:** role files (`priv/ansible/roles/**`,
 including `mimir_db` and the Alloy/datasource template changes) sync on every `mix
 ansible.build` run. The `grafana_ui`/`loki_log_aggregator`/`prometheus_db` setup

--- a/lib/deploy_ex/mimir.ex
+++ b/lib/deploy_ex/mimir.ex
@@ -39,7 +39,35 @@ defmodule DeployEx.Mimir do
   def enabled?(opts), do: not Keyword.get(opts, :no_mimir, false)
 
   @doc "Terraform variables.tf mimir_db block — empty string when mimir is disabled."
-  def terraform_variables(opts) do
+  def terraform_variables(opts, :oci) do
+    if enabled?(opts) do
+      """
+
+          mimir_db = {
+            name = "Mimir Metrics Database"
+
+            shape       = "VM.Standard.E5.Flex"
+            ocpus       = 1
+            memory_gbs  = 4
+
+            block_volume = {
+              enable   = true
+              size_gbs = 50
+            }
+
+            tags = {
+              Vendor = "Grafana"
+              Type   = "Monitoring"
+              MonitoringKey = "mimir_db"
+            }
+          },
+      """
+    else
+      ""
+    end
+  end
+
+  def terraform_variables(opts, _provider) do
     if enabled?(opts) do
       availability_zone = opts[:availability_zone] || DeployEx.Config.aws_availability_zone()
 

--- a/lib/deploy_ex/priv_renderer.ex
+++ b/lib/deploy_ex/priv_renderer.ex
@@ -184,7 +184,7 @@ defmodule DeployEx.PrivRenderer do
       terraform_grafana_variables: DeployEx.TerraformVariables.terraform_grafana_variables(opts, provider),
       terraform_loki_variables: DeployEx.TerraformVariables.terraform_loki_variables(opts, provider),
       terraform_prometheus_variables: DeployEx.TerraformVariables.terraform_prometheus_variables(opts, provider),
-      terraform_mimir_variables: DeployEx.Mimir.terraform_variables(opts)
+      terraform_mimir_variables: DeployEx.Mimir.terraform_variables(opts, provider)
     }
   end
 

--- a/lib/mix/tasks/terraform.build.ex
+++ b/lib/mix/tasks/terraform.build.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Terraform.Build do
         terraform_grafana_variables: DeployEx.TerraformVariables.terraform_grafana_variables(opts, provider),
         terraform_loki_variables: DeployEx.TerraformVariables.terraform_loki_variables(opts, provider),
         terraform_prometheus_variables: DeployEx.TerraformVariables.terraform_prometheus_variables(opts, provider),
-        terraform_mimir_variables: DeployEx.Mimir.terraform_variables(opts),
+        terraform_mimir_variables: DeployEx.Mimir.terraform_variables(opts, provider),
       }
 
       write_terraform_template_files(params, opts, provider)

--- a/priv/terraform/providers/oci/instance.tf.eex
+++ b/priv/terraform/providers/oci/instance.tf.eex
@@ -39,6 +39,9 @@ module "oci_instance" {
   assign_public_ip     = try(each.value.assign_public_ip, var.assign_public_ip)
   ssh_public_key        = local.ssh_public_key
 
+  enable_block_volume   = try(each.value.block_volume.enable, false)
+  block_volume_size_gbs = try(each.value.block_volume.size_gbs, null)
+
   enable_load_balancer                         = try(each.value.load_balancer.enable, false)
   enable_load_balancer_https                   = try(each.value.load_balancer.enable_https, true)
   load_balancer_health_check_path              = try(each.value.load_balancer.health_check.path, "")

--- a/priv/terraform/providers/oci/modules/oci-instance/cloud_init_data.yaml.tftpl
+++ b/priv/terraform/providers/oci/modules/oci-instance/cloud_init_data.yaml.tftpl
@@ -1,0 +1,67 @@
+#cloud-config
+package_update: true
+packages:
+  - xfsprogs
+
+write_files:
+  - path: /usr/local/sbin/prepare-block-volume.sh
+    permissions: '0755'
+    owner: root:root
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      exec > >(tee /var/log/prepare-block-volume.log|logger -t prepare-block-volume -s 2>/dev/console) 2>&1
+
+      DEVICE="${device_path}"
+      MP="/data"
+
+      echo "[data-disk] Waiting for $${DEVICE} to appear..."
+      for i in $(seq 1 120); do
+        [ -e "$${DEVICE}" ] && break
+        sleep 1
+      done
+
+      if [ ! -e "$${DEVICE}" ]; then
+        echo "[data-disk] $${DEVICE} not found after waiting; exiting (nofail)."
+        exit 0
+      fi
+
+      mkdir -p "$${MP}"
+
+      # ponytail: assumes a whole-disk paravirtualized volume with no partition
+      # table, unlike AWS's script (which also handles a pre-partitioned NVMe
+      # device from a restored snapshot). This module has no snapshot-restore
+      # input, so every volume it creates is fresh from OCI — upgrade to
+      # partition-aware detection (see prepare-ebs-volume.sh's lsblk/PARTS
+      # handling) if a snapshot-restore path is ever added here.
+      FSTYPE="$(blkid -s TYPE -o value "$${DEVICE}" || true)"
+
+      if [ -n "$${FSTYPE}" ]; then
+        echo "[data-disk] Found existing filesystem $${FSTYPE} on $${DEVICE}; preserving."
+      else
+        echo "[data-disk] No filesystem detected; formatting $${DEVICE} as XFS..."
+        mkfs.xfs -f "$${DEVICE}"
+        FSTYPE="xfs"
+      fi
+
+      UUID="$(blkid -s UUID -o value "$${DEVICE}")"
+      if [ -z "$${UUID}" ]; then
+        echo "[data-disk] Could not read UUID for $${DEVICE}."
+        exit 1
+      fi
+
+      sed -i "\\|$${DEVICE}|d" /etc/fstab
+      sed -i '\|[[:space:]]/data[[:space:]]|d' /etc/fstab
+      echo "UUID=$${UUID} $${MP} $${FSTYPE} defaults,nofail,x-systemd.device-timeout=30s 0 2" >> /etc/fstab
+
+      if ! mountpoint -q "$${MP}"; then
+        mount "$${MP}"
+      fi
+
+      xfs_growfs "$${MP}" || true
+
+      echo "[data-disk] Done. Mounted $${DEVICE} ($${FSTYPE}) on $${MP}."
+
+runcmd:
+  - /usr/local/sbin/prepare-block-volume.sh

--- a/priv/terraform/providers/oci/modules/oci-instance/main.tf
+++ b/priv/terraform/providers/oci/modules/oci-instance/main.tf
@@ -1,6 +1,24 @@
 locals {
   snake_instance_name = lower(replace(var.instance_name, " ", "_"))
   kebab_instance_name = lower(replace(var.instance_name, " ", "-"))
+
+  # Paravirtualized, not iscsi: OCI's VM.Standard Flex shapes attach a paravirtualized
+  # volume directly, with no iscsiadm login step required inside the guest — the
+  # device below is simply present once the attachment resource applies. iSCSI needs
+  # `iscsiadm -m node -T <iqn> -p <ipv4>:3260 -l` run from inside the instance before
+  # the device exists at all, which has no natural home in a Terraform-only module and
+  # would leave a naive mount script finding no disk. iSCSI is only required for
+  # bare-metal shapes, which this module does not provision.
+  #
+  # ASSUMED, not measured against a live instance (see cloud_init_data.yaml.tftpl and
+  # the D1 report): /dev/oracleoci/oraclevdb is the value WE request via this
+  # resource's own `device` argument on a paravirtualized attachment — the documented
+  # OCI convention for the first data volume on an Oracle-provided Ubuntu image (the
+  # oracle-cloud-agent block-volume service creates this path via udev). It has not
+  # been observed on a booted host in this environment. If it is wrong, the prepare
+  # script fails safe (waits, times out, exits 0 with no mount — the same `nofail`
+  # shape as AWS's script) rather than mounting the wrong disk.
+  block_volume_device = "/dev/oracleoci/oraclevdb"
 }
 
 resource "oci_core_instance" "main" {
@@ -31,8 +49,17 @@ resource "oci_core_instance" "main" {
   }
 
   # ssh_authorized_keys is omitted entirely when no key is supplied — passing an empty string
-  # makes the instance unreachable with no indication why.
-  metadata = var.ssh_public_key == "" ? {} : { ssh_authorized_keys = var.ssh_public_key }
+  # makes the instance unreachable with no indication why. user_data is likewise omitted
+  # entirely when no block volume is requested, rather than shipping a no-op cloud-init
+  # payload to every instance.
+  metadata = merge(
+    var.ssh_public_key == "" ? {} : { ssh_authorized_keys = var.ssh_public_key },
+    var.enable_block_volume ? {
+      user_data = base64encode(templatefile("${path.module}/cloud_init_data.yaml.tftpl", {
+        device_path = local.block_volume_device
+      }))
+    } : {}
+  )
 
   freeform_tags = merge({
     Name          = "${var.instance_name}-${var.environment}-${count.index}"
@@ -41,4 +68,34 @@ resource "oci_core_instance" "main" {
     Environment   = var.environment
     ManagedBy     = "DeployEx"
   }, var.tags)
+}
+
+### Block Volume Start ###
+###########################
+
+resource "oci_core_volume" "data" {
+  count = var.enable_block_volume ? var.instance_count : 0
+
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  display_name        = "${local.kebab_instance_name}-data-${var.environment}-${count.index}"
+  size_in_gbs         = var.block_volume_size_gbs
+
+  freeform_tags = merge({
+    Name          = "${local.kebab_instance_name}-data-${var.environment}-${count.index}"
+    Group         = var.resource_group
+    InstanceGroup = local.snake_instance_name
+    Environment   = var.environment
+    ManagedBy     = "DeployEx"
+  }, var.tags)
+}
+
+resource "oci_core_volume_attachment" "data" {
+  count = var.enable_block_volume ? var.instance_count : 0
+
+  attachment_type = "paravirtualized"
+  instance_id     = oci_core_instance.main[count.index].id
+  volume_id       = oci_core_volume.data[count.index].id
+  device          = local.block_volume_device
+  is_read_only    = false
 }

--- a/priv/terraform/providers/oci/modules/oci-instance/variables.tf
+++ b/priv/terraform/providers/oci/modules/oci-instance/variables.tf
@@ -95,6 +95,23 @@ variable "boot_volume_size_gbs" {
   nullable    = false
 }
 
+### Block Volume ###
+#####################
+
+variable "enable_block_volume" {
+  description = "Enables a secondary Block Volume, attached and mounted at /data via cloud-init. Mirrors the AWS module's enable_ebs so a consumer's mental model transfers. Default off — an existing OCI consumer's render must not gain a volume by upgrading."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "block_volume_size_gbs" {
+  description = "Block Volume size in GB, default 50 (OCI's block-volume minimum)"
+  type        = number
+  default     = 50
+  nullable    = false
+}
+
 variable "assign_public_ip" {
   description = "Whether instances get a public IP"
   type        = bool

--- a/priv/terraform/providers/oci/variables.tf.eex
+++ b/priv/terraform/providers/oci/variables.tf.eex
@@ -170,7 +170,7 @@ variable "release_bucket_name" {
 # misspelled or unsupported key. The oci-instance module reads what it understands via try()
 # and ignores the rest, so `shappe = "..."` is accepted and quietly does nothing.
 variable "<%= @app_name %>_project" {
-  description = "Map of project names to configuration. Recognized keys: name, instance_count, shape, ocpus, memory_gbs, image_ocid, boot_volume_size_gbs, assign_public_ip, load_balancer, tags. Unrecognized keys are ignored without error."
+  description = "Map of project names to configuration. Recognized keys: name, instance_count, shape, ocpus, memory_gbs, image_ocid, boot_volume_size_gbs, block_volume, assign_public_ip, load_balancer, tags. Unrecognized keys are ignored without error."
   type        = any
 
   default = {
@@ -179,7 +179,7 @@ variable "<%= @app_name %>_project" {
 <%= @terraform_clickhouse_variables %>
 <%= @terraform_rabbitmq_variables %>
 <%= @terraform_grafana_variables %>
-<%= @terraform_prometheus_variables %>
+<%= @terraform_prometheus_variables %><%= @terraform_mimir_variables %>
 <%= @terraform_loki_variables %>
 <%= @terraform_release_variables %>
   }

--- a/test/deploy_ex/mimir_test.exs
+++ b/test/deploy_ex/mimir_test.exs
@@ -22,9 +22,9 @@ defmodule DeployEx.MimirTest do
     end
   end
 
-  describe "terraform_variables/1" do
+  describe "terraform_variables/2 on aws" do
     test "returns the mimir_db block with all required fields when enabled" do
-      content = Mimir.terraform_variables([])
+      content = Mimir.terraform_variables([], :aws)
 
       assert content =~ "mimir_db = {"
       assert content =~ ~s(name                       = "Mimir Metrics Database")
@@ -39,19 +39,47 @@ defmodule DeployEx.MimirTest do
     end
 
     test "pins instance_availability_zone from opts when provided" do
-      content = Mimir.terraform_variables(availability_zone: "us-east-1c")
+      content = Mimir.terraform_variables([availability_zone: "us-east-1c"], :aws)
 
       assert content =~ ~s(instance_availability_zone = "us-east-1c")
     end
 
     test "defaults instance_availability_zone when opts omits it" do
-      content = Mimir.terraform_variables([])
+      content = Mimir.terraform_variables([], :aws)
 
       assert content =~ ~s(instance_availability_zone = "#{DeployEx.Config.aws_availability_zone()}")
     end
 
     test "returns an empty string when :no_mimir is true" do
-      assert Mimir.terraform_variables(no_mimir: true) === ""
+      assert Mimir.terraform_variables([no_mimir: true], :aws) === ""
+    end
+  end
+
+  # SECTION: terraform_variables/2 on oci — D2, closing the gap where an OCI consumer
+  # could not render a Mimir node at all (arity-1 dropped the provider on the floor).
+  describe "terraform_variables/2 on oci" do
+    test "returns the mimir_db block with oci-shaped fields when enabled" do
+      content = Mimir.terraform_variables([], :oci)
+
+      assert content =~ "mimir_db = {"
+      assert content =~ ~s(shape       = "VM.Standard.E5.Flex")
+      assert content =~ ~r/ocpus\s*=\s*1/
+      assert content =~ ~r/memory_gbs\s*=\s*4/
+      assert content =~ ~r/block_volume\s*=\s*\{/
+      assert content =~ ~r/enable\s*=\s*true/
+      assert content =~ ~r/size_gbs\s*=\s*50/
+      refute content =~ "instance_type"
+      refute content =~ "ebs ="
+      refute content =~ "instance_availability_zone"
+      refute content =~ "enable_secondary"
+      # MonitoringKey is the ansible-inventory interface (MonitoringKey=mimir_db ->
+      # group monitoring_mimir_db). Mutation-checked manually: flipping this literal
+      # to "mimir" must turn this assertion red (see report — verified 2026-09-01).
+      assert content =~ ~s(MonitoringKey = "mimir_db")
+    end
+
+    test "returns an empty string when :no_mimir is true" do
+      assert Mimir.terraform_variables([no_mimir: true], :oci) === ""
     end
   end
 

--- a/test/mix/tasks/terraform_build_oci_block_volume_test.exs
+++ b/test/mix/tasks/terraform_build_oci_block_volume_test.exs
@@ -1,0 +1,252 @@
+defmodule Mix.Tasks.Terraform.BuildOciBlockVolumeTest do
+  # async: false — matches terraform_build_oci_lb_test.exs, this file also drives real
+  # renders through Mix.Tasks.Terraform.Build.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Terraform.Build
+
+  @module_main_tf "terraform/providers/oci/modules/oci-instance/main.tf"
+  @module_variables_tf "terraform/providers/oci/modules/oci-instance/variables.tf"
+  @cloud_init_tftpl "terraform/providers/oci/modules/oci-instance/cloud_init_data.yaml.tftpl"
+  @root_instance_tf_eex "terraform/providers/oci/instance.tf.eex"
+  @root_variables_tf_eex_oci "terraform/providers/oci/variables.tf.eex"
+  @aws_instance_main_tf "terraform/modules/aws-instance/main.tf"
+
+  defp module_main_tf, do: @module_main_tf |> DeployExHelpers.priv_folder() |> File.read!()
+  defp module_variables_tf, do: @module_variables_tf |> DeployExHelpers.priv_folder() |> File.read!()
+  defp cloud_init_tftpl, do: @cloud_init_tftpl |> DeployExHelpers.priv_folder() |> File.read!()
+  defp root_instance_tf_eex, do: @root_instance_tf_eex |> DeployExHelpers.priv_folder() |> File.read!()
+  defp root_variables_tf_eex_oci, do: @root_variables_tf_eex_oci |> DeployExHelpers.priv_folder() |> File.read!()
+  defp aws_instance_main_tf, do: @aws_instance_main_tf |> DeployExHelpers.priv_folder() |> File.read!()
+
+  defp render(args), do: capture_io(fn -> Build.run(args) end)
+
+  defp render_dir do
+    Path.join(System.tmp_dir!(), "p2_tf_bv_#{System.unique_integer([:positive])}")
+  end
+
+  # SECTION: module variables.tf — opt-in, default-off block volume knobs
+
+  describe "module variables.tf — block volume variables" do
+    test "declares enable_block_volume defaulting to false, not nullable" do
+      contents = module_variables_tf()
+
+      assert contents =~ ~r/variable\s+"enable_block_volume"\s*\{[\s\S]*?default\s*=\s*false[\s\S]*?nullable\s*=\s*false/
+    end
+
+    test "declares block_volume_size_gbs defaulting to 50 (OCI's block-volume minimum)" do
+      contents = module_variables_tf()
+
+      assert contents =~ ~r/variable\s+"block_volume_size_gbs"\s*\{[\s\S]*?default\s*=\s*50[\s\S]*?nullable\s*=\s*false/
+    end
+  end
+
+  # SECTION: module main.tf — the volume, the attachment, and cloud-init wiring
+
+  describe "module main.tf — oci_core_volume" do
+    test "gates count on enable_block_volume * instance_count (opt-in, off by default)" do
+      contents = module_main_tf()
+
+      assert contents =~ ~r/resource\s+"oci_core_volume"\s+"data"\s*\{\s*count\s*=\s*var\.enable_block_volume\s*\?\s*var\.instance_count\s*:\s*0/
+      assert contents =~ ~r/size_in_gbs\s*=\s*var\.block_volume_size_gbs/
+    end
+
+    test "tags carry Group, Environment, and ManagedBy" do
+      contents = module_main_tf()
+
+      [volume_block] = Regex.run(~r/resource\s+"oci_core_volume"\s+"data"\s*\{.*?\n\}/s, contents)
+
+      assert volume_block =~ ~s(Group         = var.resource_group)
+      assert volume_block =~ ~s(Environment   = var.environment)
+      assert volume_block =~ ~s(ManagedBy     = "DeployEx")
+    end
+  end
+
+  describe "module main.tf — oci_core_volume_attachment" do
+    test "uses paravirtualized attachment, not iscsi" do
+      contents = module_main_tf()
+
+      assert contents =~ ~r/resource\s+"oci_core_volume_attachment"\s+"data"\s*\{[\s\S]*?attachment_type\s*=\s*"paravirtualized"/
+      refute contents =~ ~r/attachment_type\s*=\s*"iscsi"/
+    end
+
+    test "gates count on enable_block_volume * instance_count, same as the volume" do
+      contents = module_main_tf()
+
+      assert contents =~ ~r/resource\s+"oci_core_volume_attachment"\s+"data"\s*\{\s*count\s*=\s*var\.enable_block_volume\s*\?\s*var\.instance_count\s*:\s*0/
+    end
+
+    test "wires instance_id and volume_id from the paired resources, not a bare [0] index" do
+      contents = module_main_tf()
+
+      assert contents =~ ~r/instance_id\s*=\s*oci_core_instance\.main\[count\.index\]\.id/
+      assert contents =~ ~r/volume_id\s*=\s*oci_core_volume\.data\[count\.index\]\.id/
+    end
+
+    test "pins device to the documented paravirtualized convention, not an AWS-shaped nvme-by-id path" do
+      contents = module_main_tf()
+
+      assert contents =~ ~r{device\s*=\s*"/dev/oracleoci/oraclevdb"}
+      refute contents =~ ~r{/dev/disk/by-id/nvme}
+    end
+  end
+
+  describe "module main.tf — instance metadata carries cloud-init user_data only when block volume is enabled" do
+    test "merges a user_data key onto metadata, gated on enable_block_volume" do
+      contents = module_main_tf()
+
+      assert contents =~ ~r/metadata\s*=\s*merge\(/
+      assert contents =~ ~r/var\.enable_block_volume\s*\?\s*\{\s*user_data\s*=/
+    end
+
+    test "ssh_authorized_keys is-empty-omits logic is preserved" do
+      contents = module_main_tf()
+
+      assert contents =~ ~r/var\.ssh_public_key\s*==\s*""\s*\?\s*\{\}\s*:\s*\{\s*ssh_authorized_keys\s*=\s*var\.ssh_public_key\s*\}/
+    end
+  end
+
+  # SECTION: cloud-init asset — properties, not AWS's text
+
+  describe "cloud_init_data.yaml.tftpl — properties mirrored from the AWS script" do
+    test "installs xfsprogs" do
+      assert cloud_init_tftpl() =~ "xfsprogs"
+    end
+
+    test "preserves an existing filesystem rather than reformatting" do
+      contents = cloud_init_tftpl()
+
+      assert contents =~ ~r/blkid\s+-s\s+TYPE/
+      assert contents =~ ~r/mkfs\.xfs/
+      # The mkfs call must be reachable only from the "no filesystem found" branch,
+      # never unconditionally — this is what makes formatting idempotent-safe.
+      # $$ (not $) is deliberate: this is a Terraform templatefile() source, where a
+      # literal shell "$" must be escaped as "$$" to survive Terraform's own ${...}
+      # interpolation pass, same convention as AWS's prepare-ebs-volume.sh.
+      assert contents =~ ~r/if\s+\[\s+-n\s+"\$\$\{FSTYPE\}"\s+\]/
+    end
+
+    test "writes an fstab entry with nofail and a device timeout" do
+      contents = cloud_init_tftpl()
+
+      assert contents =~ "nofail"
+      assert contents =~ "x-systemd.device-timeout=30s"
+      assert contents =~ "/etc/fstab"
+    end
+
+    test "is safe to re-run — mount is gated on mountpoint -q, not unconditional" do
+      contents = cloud_init_tftpl()
+
+      assert contents =~ ~r/mountpoint\s+-q/
+    end
+
+    test "attempts an xfs_growfs on every run (matches AWS's unconditional-growth call site)" do
+      assert cloud_init_tftpl() =~ ~r/xfs_growfs/
+    end
+
+    test "runcmd invokes the prepare script" do
+      contents = cloud_init_tftpl()
+
+      assert contents =~ "runcmd:"
+      assert contents =~ ~r/runcmd:\s*\n\s*-\s*\/usr\/local\/sbin\/prepare-block-volume\.sh/
+    end
+  end
+
+  # SECTION: root wiring — instance.tf.eex and variables.tf.eex
+
+  describe "root instance.tf.eex — wires block_volume via try(), matching the load_balancer pattern" do
+    test "wires enable_block_volume and block_volume_size_gbs" do
+      contents = root_instance_tf_eex()
+
+      assert contents =~ ~r/enable_block_volume\s*=\s*try\(each\.value\.block_volume\.enable,\s*false\)/
+      assert contents =~ ~r/block_volume_size_gbs\s*=\s*try\(each\.value\.block_volume\.size_gbs,\s*null\)/
+    end
+  end
+
+  describe "root variables.tf.eex (oci) — recognized keys" do
+    test "the <app>_project description lists block_volume among recognized keys" do
+      contents = root_variables_tf_eex_oci()
+
+      assert contents =~ ~r/variable\s+"<%= @app_name %>_project"\s*\{\s*description\s*=\s*"[^"]*Recognized keys:[^"]*\bblock_volume\b[^"]*"/
+    end
+  end
+
+  # SECTION: AWS byte-parity — D1 must not perturb the AWS path at all
+
+  describe "AWS byte-parity regression guard" do
+    test "aws-instance/main.tf has no oci_ resources and no block-volume additions" do
+      contents = aws_instance_main_tf()
+
+      refute contents =~ ~r/oci_/
+      refute contents =~ "enable_block_volume"
+      refute contents =~ "paravirtualized"
+    end
+  end
+
+  # SECTION: render invariant — toggling mimir on an oci render changes ONLY root
+  # variables.tf's mimir_db block, nothing else in the whole tree (D1's own
+  # infrastructure — the module's volume/attachment resources and the two
+  # instance.tf wiring lines — is present identically whether or not any app
+  # requests it, since it is generic opt-in support, not mimir-specific).
+
+  defp file_tree(dir) do
+    dir
+    |> Path.join("**/*")
+    |> Path.wildcard(match_dot: true)
+    |> Enum.map(&Path.relative_to(&1, dir))
+    |> Enum.sort()
+  end
+
+  describe "render invariant — oci mimir on vs off" do
+    test "the whole-tree diff is confined to variables.tf, and its diff is exactly the mimir_db block" do
+      off_dir = render_dir()
+      on_exit(fn -> File.rm_rf!(off_dir) end)
+      render(["--provider", "oci", "--render-dir", off_dir, "--pem-app-name", "p2-bv-invariant", "--no-mimir", "--quiet"])
+
+      on_dir = render_dir()
+      on_exit(fn -> File.rm_rf!(on_dir) end)
+      render(["--provider", "oci", "--render-dir", on_dir, "--pem-app-name", "p2-bv-invariant", "--quiet"])
+
+      assert file_tree(off_dir) === file_tree(on_dir)
+
+      changed_files =
+        for relative_path <- file_tree(off_dir),
+            File.regular?(Path.join(off_dir, relative_path)),
+            File.read!(Path.join(off_dir, relative_path)) !== File.read!(Path.join(on_dir, relative_path)) do
+          relative_path
+        end
+
+      assert changed_files === ["variables.tf"]
+
+      off_variables_tf = File.read!(Path.join(off_dir, "variables.tf"))
+      on_variables_tf = File.read!(Path.join(on_dir, "variables.tf"))
+
+      refute off_variables_tf =~ "mimir_db"
+      assert on_variables_tf =~ "mimir_db = {"
+      assert on_variables_tf =~ ~r/block_volume\s*=\s*\{\s*enable\s*=\s*true/
+    end
+  end
+
+  # SECTION: full render — the cloud-init asset actually ships, and the AWS render is untouched
+
+  describe "render — cloud-init asset ships in an oci render, never in an aws render" do
+    test "oci render carries cloud_init_data.yaml.tftpl.eex output flattened alongside the module" do
+      dir = render_dir()
+      on_exit(fn -> File.rm_rf!(dir) end)
+      render(["--provider", "oci", "--render-dir", dir, "--pem-app-name", "p2-bv-render", "--quiet"])
+
+      assert File.exists?(Path.join(dir, "modules/oci-instance/cloud_init_data.yaml.tftpl"))
+    end
+
+    test "aws render never gains a providers/ dir or an oci-instance module" do
+      dir = render_dir()
+      on_exit(fn -> File.rm_rf!(dir) end)
+      render(["--render-dir", dir, "--pem-app-name", "p2-bv-render-aws", "--quiet"])
+
+      refute File.dir?(Path.join(dir, "providers"))
+      refute File.dir?(Path.join(dir, "modules/oci-instance"))
+    end
+  end
+end


### PR DESCRIPTION
Re-lands `931ddfc` (secondary block volume for the oci-instance module + provider-aware
Mimir) onto this branch's current head. That commit sits on a rebase lineage that is not
an ancestor of this branch, so its content was ported by patch application rather than
cherry-pick/merge (both were checked non-destructively first; see report).

## What changed

- `DeployEx.Mimir.terraform_variables/1` -> `/2`, adding an `:oci` clause. Zero arity-1
  definitions remain; both call sites (`priv_renderer.ex`, `terraform.build.ex`) already
  had `provider` in scope and pass it through.
- `oci-instance` module gains opt-in, default-off `enable_block_volume` /
  `block_volume_size_gbs`, wired the same way `load_balancer` already is.
- New cloud-init asset formats-and-mounts `/data` on first boot (idempotent, safe re-run).
- AWS path untouched.

## Also verified (not part of this diff)

A separate audit compared this branch against `opgg/main` commit-by-commit
(`git patch-id --stable` on all 24 nominally-shared commits, not just subject match).
21 were byte-equivalent, 1 was whitespace-only, and 3 showed real content divergence.
Directional tree comparison on those 3 confirmed this branch is the successor in every
case (this branch is a strict superset on the surfaces that mattered); nothing from
`opgg/main` needed to move. Full evidence in the harness report for this lane.

## Verification

- `mix compile --warnings-as-errors` -> exit 0
- `mix test` -> 1004 tests, 0 failures (baseline on this branch's head, measured fresh
  this session, was 980 tests / 0 failures; +24 accounted for exactly by the ported test
  files: mimir_test.exs 13->15, terraform_build_oci_block_volume_test.exs new at 22)
- `block_volume` mutation check: removed the `:oci` clause's `block_volume` block ->
  test went red (`block_volume\s*=\s*\{` assertion failed) -> restored -> green again
- `git log --merges` on this branch's range -> empty

## Verified by the project lead, on the merge result

`feat/oci-multi-cloud` was confirmed **unmoved** at `60feb92` immediately before merging, so the numbers below describe what merging produces rather than what the branch looked like when it was cut.

| gate | result | control |
|---|---|---|
| `mix test` | **1004, 0 failures** | baseline on `60feb92` untouched was **980/0**, measured first; +24 = `mimir_test.exs` 13→15 plus a 22-test block-volume file |
| `mix compile --warnings-as-errors` | exit **0** | — |
| `git log --merges 60feb92..524cc2b` | empty | — |
| arity-1 `terraform_variables` remaining | **0** | arity-2 clause count is **2**, so the grep discriminates |
| both call sites pass `provider` | yes — `terraform.build.ex`, `priv_renderer.ex` | — |
| `block_volume` in `oci-instance/variables.tf` | **2** | base `60feb92` had **0** |
| `cloud_init_data.yaml.tftpl` | present on the PR head | — |

Presence checks were run against `524cc2b` itself, not against the branch the content came from.

## What this unblocks, stated plainly

The `mimir_db` role **cannot install** without a mounted `/data`: its first task asserts `/data` is in `ansible_facts.mounts`, the systemd unit carries `RequiresMountsFor=/data`, and every path in `mimir-config.yaml.j2` is under `/data/mimir/*` with no fallback. Before this PR, this line had Mimir and no way to provide that mount. It now has both.

That is a necessary condition, not a sufficient one — nothing here has been applied to a host.

## Note on how "applies cleanly" was established

`git merge-tree --write-tree` against the whole 43-commit divergent branch reports 7 conflicts; `git show <sha> | git apply --check --3way` reports the 11-file payload applying cleanly. Both are correct answers to different questions, and the relevant one was whether this commit's declared payload applies.

Worth stating for anyone reusing that technique: **`apply --check --3way` proves a patch lands textually, not that the result is correct.** Correctness here rests on RED→GREEN, a mutation arm that removed `block_volume` from the `:oci` clause and showed the assertion go red before restoring it, and the full suite at 1004/0.
