### PR TITLE
fix(load_test): stop swallowing prometheus discovery errors

### DIFF
--- a/lib/mix/tasks/deploy_ex.load_test.exec.ex
+++ b/lib/mix/tasks/deploy_ex.load_test.exec.ex
@@ -118,7 +118,16 @@ defmodule Mix.Tasks.DeployEx.LoadTest.Exec do
   defp resolve_discovered_prometheus_url(discover_fn) do
     case discover_fn.() do
       {:ok, ip} when is_binary(ip) -> {:ok, "http://#{ip}:9090"}
-      _ -> {:ok, nil}
+      {:ok, nil} -> {:ok, nil}
+
+      # `not_found` today conflates "no prometheus configured for this fleet" with
+      # "prometheus is configured but nothing is running" — both mean "no URL to hand
+      # the load test" to every caller that exists right now. If anyone ever needs to
+      # alarm on down-ness specifically, that distinction has to be pushed into the
+      # provider and this clause split in two.
+      {:error, %ErrorMessage{code: :not_found}} -> {:ok, nil}
+
+      {:error, error} -> {:error, error}
     end
   end
 

--- a/test/mix/tasks/deploy_ex_load_test_exec_test.exs
+++ b/test/mix/tasks/deploy_ex_load_test_exec_test.exs
@@ -96,10 +96,17 @@ defmodule Mix.Tasks.DeployEx.LoadTest.ExecTest do
       assert {:ok, "http://10.0.101.171:9090"} = Exec.resolve_prometheus_url([], discover)
     end
 
-    test "returns nil when discovery finds no prometheus node" do
-      discover = fn -> {:error, :not_found} end
+    test "treats a not_found discovery error as an absent prometheus node, not a failure — absence is a supported fleet configuration" do
+      discover = fn -> {:error, ErrorMessage.not_found("no running prometheus node found")} end
 
       assert {:ok, nil} = Exec.resolve_prometheus_url([], discover)
+    end
+
+    test "propagates a non-not_found discovery error instead of silently downgrading it to {:ok, nil}" do
+      error = ErrorMessage.internal_server_error("aws api unavailable")
+      discover = fn -> {:error, error} end
+
+      assert {:error, ^error} = Exec.resolve_prometheus_url([], discover)
     end
   end
 


### PR DESCRIPTION
## The defect

`resolve_discovered_prometheus_url/1` ended in a bare catch-all:

```elixir
{:ok, ip} when is_binary(ip) -> {:ok, "http://#{ip}:9090"}
_ -> {:ok, nil}
```

`find_running_prometheus_ip/1` builds a correct `ErrorMessage.not_found/1`, and
`discover_prometheus_ip/0` passes provider errors through untouched — then the catch-all
discards all of it one frame later.

Effect: discovery fails for any reason (credentials, API error, provider fault) → `{:ok, nil}`
→ the Prometheus flag drops → one warning line prints → **the load test runs and exits 0 having
exported nothing.** No step raises.

## The fix

Named clauses, no catch-all:

| `discover_fn.()` returns | result |
|---|---|
| `{:ok, ip}` when binary | `{:ok, "http://ip:9090"}` — unchanged |
| `{:ok, nil}` | `{:ok, nil}` — unchanged, pinned by an existing test |
| `{:error, %ErrorMessage{code: :not_found}}` | `{:ok, nil}` — absence is a supported configuration |
| any other error | **propagated** |

Absence deliberately stays a success: some fleets legitimately run no Prometheus, and making
that an error would break a correctly configured fleet. The propagated error surfaces through
the existing `with ... else {:error, error} -> Mix.raise(ErrorMessage.to_string(error))`.

A comment at the `not_found` clause records the known ceiling: `not_found` currently conflates
"no Prometheus configured here" with "configured but nothing running". Both mean the same thing
to every caller that exists today; if anyone needs to alarm on down-ness, the distinction has to
be pushed into the provider and that clause splits.

## Tests

`test/mix/tasks/deploy_ex_load_test_exec_test.exs`, via the `discover_fn` injection seam that
already existed — no new seam. One test added (non-`not_found` error propagates), one renamed:
it previously injected a bare `:not_found` atom, a shape `discover_prometheus_ip/0` never
produces, so it now uses a real `ErrorMessage`.

No end-to-end check: the end-to-end path is exactly the one that could not go red for this
defect, which is what made it survivable.

Both clauses were mutation-tested independently — restoring the catch-all fails the propagation
test; removing the `not_found` clause fails the absence test. Neither guard is decorative.

- Baseline `main` @ `6dedca4`: 708 tests, 0 failures
- Branch tip: 709 tests, 0 failures (+1 = the added test)
- `mix compile --warnings-as-errors --force`: exit 0
